### PR TITLE
ci: Add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,607 +1,193 @@
-name: CI Pipeline
+name: CI
 
 on:
-  push:
-    branches: [main, master, develop]
   pull_request:
-    branches: [main, master, develop]
+    branches: [master, main]
+  push:
+    branches: [master, main]
 
 env:
-  GO_VERSION: '1.22'
+  GO_VERSION: '1.23'
   NODE_VERSION: '20'
 
 jobs:
-  # ============================================
-  # Go Backend - Lint, Test, Build
-  # ============================================
-  go-lint:
-    name: Go Lint
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
-      - name: golangci-lint
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
           version: latest
           args: --timeout=5m
-          working-directory: ./
 
-  go-test:
-    name: Go Tests
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
-      - name: Download dependencies
+      - name: Run tests
         run: |
-          go mod download
-          cd cmd/gateway && go mod download
-          cd ../agent && go mod download
+          go test -v -race -coverprofile=coverage.out ./...
+        env:
+          CGO_ENABLED: 1
 
-      - name: Install go-junit-report
-        run: go install github.com/jstemmer/go-junit-report/v2@latest
-
-      - name: Run Gateway Tests
-        run: |
-          cd cmd/gateway
-          mkdir -p test-results
-          go test -v -race -coverprofile=coverage-gateway.out ./... 2>&1 | tee test-output.txt
-          cat test-output.txt | go-junit-report -set-exit-code > test-results/gateway-junit.xml
-
-      - name: Run Agent Tests
-        run: |
-          cd cmd/agent
-          mkdir -p test-results
-          go test -v -race -coverprofile=coverage-agent.out ./... 2>&1 | tee test-output.txt
-          cat test-output.txt | go-junit-report -set-exit-code > test-results/agent-junit.xml
-
-      - name: Run Common Tests
-        run: |
-          cd internal/common
-          mkdir -p test-results
-          go test -v -race -coverprofile=coverage-common.out ./... 2>&1 | tee test-output.txt
-          cat test-output.txt | go-junit-report -set-exit-code > test-results/common-junit.xml
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: go-test-results
-          path: |
-            cmd/gateway/test-results/
-            cmd/agent/test-results/
-            internal/common/test-results/
-            cmd/gateway/coverage-gateway.out
-            cmd/agent/coverage-agent.out
-            internal/common/coverage-common.out
-
-      - name: Upload coverage reports
+      - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:
-          files: cmd/gateway/coverage-gateway.out,cmd/agent/coverage-agent.out,internal/common/coverage-common.out
+          files: ./coverage.out
           fail_ci_if_error: false
 
-  go-build:
-    name: Go Build
+  build-gateway:
+    name: Build Gateway
     runs-on: ubuntu-latest
-    needs: [go-lint, go-test]
-    strategy:
-      matrix:
-        goos: [linux, darwin]
-        goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Build Gateway
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
         run: |
           cd cmd/gateway
-          go build -ldflags="-s -w -X main.Version=${{ github.sha }} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o ../../bin/gateway-${{ matrix.goos }}-${{ matrix.goarch }} .
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o gateway-linux-amd64 .
+          echo "Gateway binary built successfully"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-linux-amd64
+          path: cmd/gateway/gateway-linux-amd64
+          retention-days: 1
+
+  build-agent:
+    name: Build Agent
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Build Agent
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
         run: |
           cd cmd/agent
-          go build -ldflags="-s -w -X main.Version=${{ github.sha }} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o ../../bin/agent-${{ matrix.goos }}-${{ matrix.goarch }} .
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o agent-linux-amd64 .
+          echo "Agent binary built successfully"
 
-      - name: Upload artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: bin/
+          name: agent-linux-amd64
+          path: cmd/agent/agent-linux-amd64
+          retention-days: 1
 
-  # ============================================
-  # Security Scanning
-  # ============================================
-  security-scan:
-    name: Security Scan (SAST/SCA)
+  build-frontend:
+    name: Build Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          submodules: recursive
 
-      - name: Run Gosec Security Scanner (SAST)
-        uses: securego/gosec@master
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
+          node-version: ${{ env.NODE_VERSION }}
 
-      - name: Upload Gosec SARIF
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
         with:
-          sarif_file: gosec-results.sarif
-          category: gosec
-        if: always()
+          version: 9
 
-      - name: Run Go vulnerability check (SCA)
+      - name: Get pnpm store directory
+        shell: bash
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-  secret-scanning:
-    name: Secret Scanning
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
         with:
-          fetch-depth: 0
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
-      - name: Gitleaks Secret Scan
-        uses: gitleaks/gitleaks-action@v2
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        working-directory: frontend
+        run: pnpm build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
+          NEXT_PUBLIC_BASE_PATH: /avika
 
-  frontend-security:
-    name: Frontend Security (SCA)
+  docker-build-test:
+    name: Docker Build Test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
+    needs: [build-gateway, build-agent]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: NPM Audit (SCA)
-        run: npm audit --audit-level=high || true
-
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
-        continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --severity-threshold=high
-
-  container-security:
-    name: Container Security Scan
-    runs-on: ubuntu-latest
-    needs: [go-build]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    strategy:
-      matrix:
-        component: [gateway, agent, frontend]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build Docker Image
-        run: |
-          if [ "${{ matrix.component }}" = "gateway" ]; then
-            docker build -f cmd/gateway/Dockerfile -t ${{ matrix.component }}:scan .
-          elif [ "${{ matrix.component }}" = "agent" ]; then
-            docker build -f deploy/docker/Dockerfile.agent -t ${{ matrix.component }}:scan .
-          else
-            docker build -f frontend/Dockerfile -t ${{ matrix.component }}:scan ./frontend
-          fi
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ matrix.component }}:scan'
-          format: 'sarif'
-          output: 'trivy-${{ matrix.component }}.sarif'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-${{ matrix.component }}.sarif'
-          category: 'trivy-${{ matrix.component }}'
-        if: always()
-
-  owasp-dependency-check:
-    name: OWASP Dependency Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install frontend dependencies
-        run: cd frontend && npm ci
-
-      - name: OWASP Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@main
-        with:
-          project: 'avika-nginx-manager'
-          path: '.'
-          format: 'HTML,SARIF'
-          args: >
-            --enableExperimental
-            --failOnCVSS 8
-            --suppression .dependency-check-suppression.xml
-        continue-on-error: true
-
-      - name: Upload OWASP results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: owasp-dependency-check
-          path: reports/
-
-      - name: Upload OWASP SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: reports/dependency-check-report.sarif
-          category: owasp-dependency-check
-        if: always()
-
-  sbom-generation:
-    name: SBOM Generation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Generate SBOM with Syft
-        uses: anchore/sbom-action@v0
-        with:
-          format: spdx-json
-          output-file: sbom.spdx.json
-
-      - name: Upload SBOM
-        uses: actions/upload-artifact@v4
-        with:
-          name: sbom
-          path: sbom.spdx.json
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v4
-        with:
-          fail-on-severity: high
-
-  # ============================================
-  # Frontend - Lint, Test, Build
-  # ============================================
-  frontend-lint:
-    name: Frontend Lint
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run ESLint
-        run: npm run lint
-
-      - name: Run TypeScript check
-        run: npx tsc --noEmit
-
-  frontend-test:
-    name: Frontend Tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run unit tests
-        run: |
-          mkdir -p test-results coverage
-          npm run test:unit -- --reporter=default --reporter=junit --outputFile=test-results/junit.xml --coverage
-
-      - name: Upload frontend test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: frontend-test-results
-          path: |
-            frontend/test-results/
-            frontend/coverage/
-
-  frontend-build:
-    name: Frontend Build
-    runs-on: ubuntu-latest
-    needs: [frontend-lint]
-    defaults:
-      run:
-        working-directory: ./frontend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-        env:
-          NEXT_PUBLIC_GATEWAY_URL: http://localhost:5020
-          NEXT_PUBLIC_WS_URL: ws://localhost:5021
-
-  # ============================================
-  # Docker Build (on main/master only)
-  # ============================================
-  docker-build:
-    name: Docker Build
-    runs-on: ubuntu-latest
-    needs: [go-build, frontend-build]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    strategy:
-      matrix:
-        component: [gateway, agent, frontend]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
-
-      - name: Build and push Gateway
-        if: matrix.component == 'gateway'
+      - name: Build Gateway Image (test)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./cmd/gateway/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-gateway:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-gateway:latest
-          build-args: |
-            VERSION=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+          push: false
+          tags: avika-gateway:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Build and push Agent
-        if: matrix.component == 'agent'
+      - name: Build Agent Image (test)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./deploy/docker/Dockerfile.agent
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-agent:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-agent:latest
+          push: false
+          tags: avika-agent:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Build and push Frontend
-        if: matrix.component == 'frontend'
+      - name: Build Frontend Image (test)
         uses: docker/build-push-action@v5
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-frontend:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-frontend:latest
-
-  # ============================================
-  # Helm Chart Validation
-  # ============================================
-  helm-lint:
-    name: Helm Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.0
-
-      - name: Lint Helm chart
-        run: helm lint ./deploy/helm/nginx-manager
-
-      - name: Template Helm chart
-        run: helm template test ./deploy/helm/nginx-manager --debug > /dev/null
-
-  # ============================================
-  # Integration Tests (on PRs to main)
-  # ============================================
-  integration-tests:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    needs: [go-build]
-    if: github.event_name == 'pull_request'
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: admin
-          POSTGRES_PASSWORD: testpassword
-          POSTGRES_DB: avika
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      clickhouse:
-        image: clickhouse/clickhouse-server:24.1
-        ports:
-          - 8123:8123
-          - 9000:9000
-        options: >-
-          --health-cmd "wget --spider -q http://localhost:8123/ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Run integration tests
-        run: |
-          cd cmd/gateway
-          go test -v -tags=integration ./...
-        env:
-          DB_DSN: postgres://admin:testpassword@localhost:5432/avika?sslmode=disable
-          CLICKHOUSE_ADDR: localhost:9000
-
-  # ============================================
-  # E2E Tests (on PRs to main)
-  # ============================================
-  e2e-tests:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    needs: [frontend-build, go-build]
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        working-directory: ./frontend
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: ./frontend
-        run: npx playwright install --with-deps chromium
-
-      - name: Build frontend
-        working-directory: ./frontend
-        run: npm run build
-        env:
-          NEXT_PUBLIC_GATEWAY_URL: http://localhost:5020
-          NEXT_PUBLIC_WS_URL: ws://localhost:5021
-
-      - name: Start frontend server
-        working-directory: ./frontend
-        run: npm run start &
-        env:
-          PORT: 3000
-
-      - name: Wait for frontend
-        run: |
-          for i in {1..30}; do
-            curl -s http://localhost:3000 > /dev/null && break
-            sleep 1
-          done
-
-      - name: Run E2E tests
-        working-directory: ./frontend
-        run: npx playwright test --reporter=html,junit
-        env:
-          NEXT_PUBLIC_GATEWAY_URL: http://localhost:5020
-          NEXT_PUBLIC_WS_URL: ws://localhost:5021
-          PLAYWRIGHT_JUNIT_OUTPUT_NAME: test-results/e2e-results.xml
-
-      - name: Upload E2E test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: e2e-test-results
-          path: |
-            frontend/playwright-report/
-            frontend/test-results/
+          push: false
+          tags: avika-frontend:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,117 +1,179 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Release version (e.g., v1.2.3)'
+      bump_type:
+        description: 'Version bump type'
         required: true
-        type: string
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      prerelease:
+        description: 'Pre-release suffix (e.g., rc.1, beta.1, leave empty for stable)'
+        required: false
+        default: ''
 
 env:
-  GO_VERSION: '1.22'
+  GO_VERSION: '1.23'
   NODE_VERSION: '20'
-
-permissions:
-  contents: write
-  packages: write
+  DOCKERHUB_USERNAME: hellodk
 
 jobs:
-  # ============================================
-  # Build Release Binaries
-  # ============================================
+  version-bump:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      tag: ${{ steps.bump.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "hellodk"
+          git config user.email "hello.dk@outlook.com"
+
+      - name: Bump version
+        id: bump
+        run: |
+          # Read current version
+          CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
+          echo "Current version: $CURRENT_VERSION"
+          
+          # Parse version components
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          
+          # Bump based on type
+          case "${{ inputs.bump_type }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          # Construct new version
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          
+          # Add prerelease suffix if specified
+          if [ -n "${{ inputs.prerelease }}" ]; then
+            NEW_VERSION="${NEW_VERSION}-${{ inputs.prerelease }}"
+          fi
+          
+          echo "New version: $NEW_VERSION"
+          
+          # Update VERSION file
+          echo "$NEW_VERSION" > VERSION
+          
+          # Commit and tag
+          git add VERSION
+          git commit -m "chore: Bump version to ${NEW_VERSION}"
+          git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
+          
+          # Push changes
+          git push origin HEAD
+          git push origin "v${NEW_VERSION}"
+          
+          # Set outputs
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=v${NEW_VERSION}" >> $GITHUB_OUTPUT
+
   build-binaries:
     name: Build Binaries
     runs-on: ubuntu-latest
+    needs: version-bump
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
+        include:
+          # Linux
+          - goos: linux
+            goarch: amd64
+            suffix: linux-amd64
+          - goos: linux
             goarch: arm64
+            suffix: linux-arm64
+          # macOS
+          - goos: darwin
+            goarch: amd64
+            suffix: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            suffix: darwin-arm64
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.version-bump.outputs.version }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Get version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
+          cache: true
 
       - name: Build Gateway
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
         run: |
           cd cmd/gateway
-          EXT=""
-          if [ "${{ matrix.goos }}" == "windows" ]; then
-            EXT=".exe"
-          fi
-          go build -ldflags="-s -w \
-            -X main.Version=${{ steps.version.outputs.VERSION }} \
-            -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-            -X main.GitCommit=${{ github.sha }}" \
-            -o ../../dist/gateway-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} .
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -ldflags="-s -w -X main.Version=${{ needs.version-bump.outputs.version }}" \
+            -o gateway-${{ matrix.suffix }} .
 
       - name: Build Agent
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
         run: |
           cd cmd/agent
-          EXT=""
-          if [ "${{ matrix.goos }}" == "windows" ]; then
-            EXT=".exe"
-          fi
-          go build -ldflags="-s -w \
-            -X main.Version=${{ steps.version.outputs.VERSION }} \
-            -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-            -X main.GitCommit=${{ github.sha }}" \
-            -o ../../dist/agent-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} .
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -ldflags="-s -w -X main.Version=${{ needs.version-bump.outputs.version }}" \
+            -o agent-${{ matrix.suffix }} .
 
-      - name: Create checksums
-        run: |
-          cd dist
-          sha256sum * > checksums-${{ matrix.goos }}-${{ matrix.goarch }}.txt
-
-      - name: Upload artifacts
+      - name: Upload Gateway artifact
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/
+          name: gateway-${{ matrix.suffix }}
+          path: cmd/gateway/gateway-${{ matrix.suffix }}
 
-  # ============================================
-  # Build Docker Images
-  # ============================================
-  build-docker:
-    name: Build Docker Images
+      - name: Upload Agent artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-${{ matrix.suffix }}
+          path: cmd/agent/agent-${{ matrix.suffix }}
+
+  build-push-images:
+    name: Build & Push Docker Images
     runs-on: ubuntu-latest
+    needs: version-bump
+    strategy:
+      matrix:
+        image:
+          - name: gateway
+            dockerfile: cmd/gateway/Dockerfile
+            context: .
+          - name: frontend
+            dockerfile: frontend/Dockerfile
+            context: ./frontend
+          - name: agent
+            dockerfile: deploy/docker/Dockerfile.agent
+            context: .
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Get version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.version-bump.outputs.version }}
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -119,193 +181,175 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          images: ${{ env.DOCKERHUB_USERNAME }}/avika-${{ matrix.image.name }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.version-bump.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version-bump.outputs.version }}
+            type=raw,value=latest,enable=${{ !contains(needs.version-bump.outputs.version, '-') }}
+            type=sha,prefix=sha-
 
-      - name: Build and push Gateway
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: ./cmd/gateway/Dockerfile
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-gateway:${{ steps.version.outputs.VERSION }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-gateway:latest
-            ghcr.io/${{ github.repository_owner }}/nginx-gateway:${{ steps.version.outputs.VERSION }}
-            ghcr.io/${{ github.repository_owner }}/nginx-gateway:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
-            VERSION=${{ steps.version.outputs.VERSION }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-            GIT_COMMIT=${{ github.sha }}
+            VERSION=${{ needs.version-bump.outputs.version }}
 
-      - name: Build and push Agent
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./deploy/docker/Dockerfile.agent
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-agent:${{ steps.version.outputs.VERSION }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-agent:latest
-            ghcr.io/${{ github.repository_owner }}/nginx-agent:${{ steps.version.outputs.VERSION }}
-            ghcr.io/${{ github.repository_owner }}/nginx-agent:latest
-
-      - name: Build and push Frontend
-        uses: docker/build-push-action@v5
-        with:
-          context: ./frontend
-          file: ./frontend/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-frontend:${{ steps.version.outputs.VERSION }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/nginx-frontend:latest
-            ghcr.io/${{ github.repository_owner }}/nginx-frontend:${{ steps.version.outputs.VERSION }}
-            ghcr.io/${{ github.repository_owner }}/nginx-frontend:latest
-
-  # ============================================
-  # Create GitHub Release
-  # ============================================
-  create-release:
-    name: Create Release
+  package-helm:
+    name: Package Helm Chart
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-docker]
+    needs: version-bump
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: v${{ needs.version-bump.outputs.version }}
 
-      - name: Get version
-        id: version
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.0
+
+      - name: Update Chart version
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
+          cd deploy/helm/avika
+          # Update Chart.yaml with new version
+          sed -i "s/^version:.*/version: ${{ needs.version-bump.outputs.version }}/" Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${{ needs.version-bump.outputs.version }}\"/" Chart.yaml
+
+      - name: Package Helm chart
+        run: |
+          helm package deploy/helm/avika --destination ./helm-package
+
+      - name: Upload Helm chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-chart
+          path: ./helm-package/*.tgz
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [version-bump, build-binaries, build-push-images, package-helm]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.version-bump.outputs.version }}
+          fetch-depth: 0
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: artifacts/
+          path: ./artifacts
 
-      - name: Organize release files
+      - name: Prepare release assets
         run: |
-          mkdir -p release
-          cp artifacts/binaries-*/* release/ || true
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          # Get the previous tag
-          PREV_TAG=$(git describe --abbrev=0 --tags HEAD^ 2>/dev/null || echo "")
+          mkdir -p release-assets
           
-          if [ -z "$PREV_TAG" ]; then
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            echo "## Initial Release" >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            git log --pretty=format:"- %s" | head -20 >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            echo "## Changes since $PREV_TAG" >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            git log ${PREV_TAG}..HEAD --pretty=format:"- %s" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
+          # Move binaries
+          find ./artifacts -name 'gateway-*' -type f -exec mv {} release-assets/ \;
+          find ./artifacts -name 'agent-*' -type f -exec mv {} release-assets/ \;
+          
+          # Move Helm chart
+          find ./artifacts -name '*.tgz' -type f -exec mv {} release-assets/ \;
+          
+          # Make binaries executable
+          chmod +x release-assets/gateway-* release-assets/agent-* 2>/dev/null || true
+          
+          # Generate checksums
+          cd release-assets
+          sha256sum * > checksums.txt
+          cat checksums.txt
 
-      - name: Create Release
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          # Get commits since last tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating notes from $PREV_TAG to v${{ needs.version-bump.outputs.version }}"
+            COMMITS=$(git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD)
+          else
+            echo "No previous tag found, using recent commits"
+            COMMITS=$(git log --pretty=format:"- %s (%h)" -20)
+          fi
+          
+          # Create release notes
+          cat << EOF > release-notes.md
+          ## What's Changed
+          
+          $COMMITS
+          
+          ## Docker Images
+          
+          \`\`\`bash
+          docker pull hellodk/avika-gateway:${{ needs.version-bump.outputs.version }}
+          docker pull hellodk/avika-frontend:${{ needs.version-bump.outputs.version }}
+          docker pull hellodk/avika-agent:${{ needs.version-bump.outputs.version }}
+          \`\`\`
+          
+          ## Binaries
+          
+          | Platform | Gateway | Agent |
+          |----------|---------|-------|
+          | Linux amd64 | gateway-linux-amd64 | agent-linux-amd64 |
+          | Linux arm64 | gateway-linux-arm64 | agent-linux-arm64 |
+          | macOS amd64 | gateway-darwin-amd64 | agent-darwin-amd64 |
+          | macOS arm64 | gateway-darwin-arm64 | agent-darwin-arm64 |
+          
+          ## Helm Chart
+          
+          \`\`\`bash
+          helm install avika ./avika-${{ needs.version-bump.outputs.version }}.tgz
+          \`\`\`
+          
+          ## Checksums
+          
+          See \`checksums.txt\` for SHA256 checksums of all artifacts.
+          EOF
+
+      - name: Create GitHub Release (Draft)
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.version.outputs.VERSION }}
-          name: Release ${{ steps.version.outputs.VERSION }}
-          body: |
-            ## NGINX Manager ${{ steps.version.outputs.VERSION }}
-
-            ${{ steps.changelog.outputs.CHANGELOG }}
-
-            ## Docker Images
-
-            ```bash
-            # Docker Hub
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/nginx-gateway:${{ steps.version.outputs.VERSION }}
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/nginx-agent:${{ steps.version.outputs.VERSION }}
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/nginx-frontend:${{ steps.version.outputs.VERSION }}
-
-            # GitHub Container Registry
-            docker pull ghcr.io/${{ github.repository_owner }}/nginx-gateway:${{ steps.version.outputs.VERSION }}
-            docker pull ghcr.io/${{ github.repository_owner }}/nginx-agent:${{ steps.version.outputs.VERSION }}
-            docker pull ghcr.io/${{ github.repository_owner }}/nginx-frontend:${{ steps.version.outputs.VERSION }}
-            ```
-
-            ## Installation
-
-            ### Binary Installation
-            Download the appropriate binary for your platform from the assets below.
-
-            ### Helm Installation
-            ```bash
-            helm repo add nginx-manager https://your-helm-repo.example.com
-            helm install nginx-manager nginx-manager/nginx-manager --version ${{ steps.version.outputs.VERSION }}
-            ```
-
-            ## Checksums
-            See checksums files in the release assets for verification.
-          files: release/*
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.VERSION, '-') }}
+          tag_name: v${{ needs.version-bump.outputs.version }}
+          name: Avika v${{ needs.version-bump.outputs.version }}
+          body_path: release-notes.md
+          draft: true
+          prerelease: ${{ contains(needs.version-bump.outputs.version, '-') }}
+          files: |
+            release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # ============================================
-  # Publish Helm Chart
-  # ============================================
-  publish-helm:
-    name: Publish Helm Chart
-    runs-on: ubuntu-latest
-    needs: [create-release]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get version
-        id: version
+      - name: Release Summary
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${GITHUB_REF#refs/tags/}"
-          fi
-          # Remove 'v' prefix for Helm version
-          echo "VERSION=${VERSION#v}" >> $GITHUB_OUTPUT
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.0
-
-      - name: Update Chart version
-        run: |
-          sed -i "s/^version:.*/version: ${{ steps.version.outputs.VERSION }}/" deploy/helm/nginx-manager/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" deploy/helm/nginx-manager/Chart.yaml
-
-      - name: Package Helm chart
-        run: |
-          helm package deploy/helm/nginx-manager -d .cr-release-packages
-
-      - name: Upload Helm chart as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: helm-chart
-          path: .cr-release-packages/
+          echo "## Release v${{ needs.version-bump.outputs.version }} created!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker Images" >> $GITHUB_STEP_SUMMARY
+          echo "- hellodk/avika-gateway:${{ needs.version-bump.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- hellodk/avika-frontend:${{ needs.version-bump.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- hellodk/avika-agent:${{ needs.version-bump.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "1. Review the draft release at: https://github.com/${{ github.repository }}/releases" >> $GITHUB_STEP_SUMMARY
+          echo "2. Edit release notes if needed" >> $GITHUB_STEP_SUMMARY
+          echo "3. Publish the release" >> $GITHUB_STEP_SUMMARY

--- a/docs/CICD_ARCHITECTURE.md
+++ b/docs/CICD_ARCHITECTURE.md
@@ -1,0 +1,419 @@
+# CI/CD Architecture for Avika
+
+## Overview
+
+This document outlines the Continuous Integration and Continuous Deployment (CI/CD) architecture for the Avika project using GitHub Actions, DockerHub, and GitHub Releases.
+
+## Table of Contents
+
+1. [Pipeline Overview](#1-pipeline-overview)
+2. [Workflow Triggers](#2-workflow-triggers)
+3. [Build Artifacts](#3-build-artifacts)
+4. [Workflow Architecture](#4-workflow-architecture)
+5. [Secrets Management](#5-secrets-management)
+6. [Version Strategy](#6-version-strategy)
+7. [Multi-Architecture Support](#7-multi-architecture-support)
+8. [Workflow Files](#8-workflow-files)
+9. [Release Process](#9-release-process)
+10. [Cost & Performance Considerations](#10-cost--performance-considerations)
+
+---
+
+## 1. Pipeline Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              GitHub Repository                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   PR Created/Updated          Push to master            Tag v1.x.x          │
+│         │                          │                        │               │
+│         ▼                          ▼                        ▼               │
+│   ┌─────────────┐           ┌─────────────┐          ┌─────────────┐       │
+│   │  CI Build   │           │  CI Build   │          │   Release   │       │
+│   │  (No Push)  │           │  (No Push)  │          │  Workflow   │       │
+│   └─────────────┘           └─────────────┘          └──────┬──────┘       │
+│         │                          │                        │               │
+│         ▼                          ▼                        ▼               │
+│   Build & Test              Build & Test            Build, Push, Release    │
+│                                                             │               │
+└─────────────────────────────────────────────────────────────┼───────────────┘
+                                                              │
+                    ┌─────────────────────────────────────────┼─────────────────┐
+                    │                                         │                 │
+                    ▼                                         ▼                 ▼
+             ┌─────────────┐                          ┌─────────────┐   ┌─────────────┐
+             │  DockerHub  │                          │   GitHub    │   │   GitHub    │
+             │   Images    │                          │  Releases   │   │  Packages   │
+             └─────────────┘                          └─────────────┘   └─────────────┘
+```
+
+## 2. Workflow Triggers
+
+| Event | Workflow | Actions |
+|-------|----------|---------|
+| Pull Request to `master` | `ci.yml` | Build, Test, Lint (no push) |
+| Push to `master` | `ci.yml` | Build, Test, Lint (no push) |
+| Tag `v*` | `release.yml` | Build, Push Images, Create Release |
+| Manual | `release.yml` | Workflow dispatch with version input |
+
+### Trigger Configuration
+
+```yaml
+# CI Workflow (ci.yml)
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+# Release Workflow (release.yml)
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., v1.0.0)'
+        required: true
+```
+
+## 3. Build Artifacts
+
+### Docker Images
+
+| Image | Repository | Tags |
+|-------|------------|------|
+| Gateway | `hellodk/avika-gateway` | `v1.0.0`, `latest`, `sha-abc1234` |
+| Frontend | `hellodk/avika-frontend` | `v1.0.0`, `latest`, `sha-abc1234` |
+| Agent | `hellodk/avika-agent` | `v1.0.0`, `latest`, `sha-abc1234` |
+
+### Binary Artifacts
+
+| Binary | Architectures | Format |
+|--------|---------------|--------|
+| `gateway` | linux/amd64, linux/arm64 | `gateway-linux-amd64`, `gateway-linux-arm64` |
+| `agent` | linux/amd64, linux/arm64 | `agent-linux-amd64`, `agent-linux-arm64` |
+
+### Optional Architectures (if needed)
+
+| OS/Arch | Gateway | Agent | Notes |
+|---------|---------|-------|-------|
+| darwin/amd64 | ✓ | ✓ | macOS Intel |
+| darwin/arm64 | ✓ | ✓ | macOS Apple Silicon |
+| windows/amd64 | ✓ | ✗ | Agent typically runs on Linux |
+
+## 4. Workflow Architecture
+
+### 4.1 CI Workflow (`ci.yml`)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                       CI Workflow                            │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐  │
+│  │  Lint   │    │  Test   │    │  Build  │    │  Build  │  │
+│  │   Go    │    │   Go    │    │ Gateway │    │  Agent  │  │
+│  └─────────┘    └─────────┘    └─────────┘    └─────────┘  │
+│       │              │              │              │        │
+│       └──────────────┴──────────────┴──────────────┘        │
+│                           │                                 │
+│                           ▼                                 │
+│                    ┌─────────────┐                          │
+│                    │   Build     │                          │
+│                    │  Frontend   │                          │
+│                    └─────────────┘                          │
+│                           │                                 │
+│                           ▼                                 │
+│                    ┌─────────────┐                          │
+│                    │   Docker    │                          │
+│                    │ Build Test  │                          │
+│                    │ (no push)   │                          │
+│                    └─────────────┘                          │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Release Workflow (`release.yml`)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           Release Workflow                                   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  Stage 1: Build Binaries (parallel)                                         │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ Build Gateway   │  │ Build Gateway   │  │  Build Agent    │             │
+│  │ linux/amd64     │  │ linux/arm64     │  │ linux/amd64     │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+│           │                    │                    │                       │
+│  ┌────────┴────────┐          │           ┌────────┴────────┐             │
+│  │  Build Agent    │          │           │   Upload to     │             │
+│  │  linux/arm64    │          │           │   Artifacts     │             │
+│  └────────┬────────┘          │           └────────┬────────┘             │
+│           │                    │                    │                       │
+│           └────────────────────┴────────────────────┘                       │
+│                                │                                            │
+│  Stage 2: Build & Push Docker Images                                        │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
+│  │ Build & Push    │  │ Build & Push    │  │ Build & Push    │             │
+│  │ Gateway Image   │  │ Frontend Image  │  │ Agent Image     │             │
+│  │ (multi-arch)    │  │ (multi-arch)    │  │ (multi-arch)    │             │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
+│           │                    │                    │                       │
+│           └────────────────────┴────────────────────┘                       │
+│                                │                                            │
+│  Stage 3: Create GitHub Release                                             │
+│  ┌─────────────────────────────────────────────────────────────┐           │
+│  │  Create Release with:                                        │           │
+│  │  - Release notes (from CHANGELOG or auto-generated)          │           │
+│  │  - Binary artifacts (gateway-*, agent-*)                     │           │
+│  │  - Checksums (SHA256)                                        │           │
+│  └─────────────────────────────────────────────────────────────┘           │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 5. Secrets Management
+
+### Required GitHub Secrets
+
+| Secret | Description | Required For |
+|--------|-------------|--------------|
+| `DOCKERHUB_USERNAME` | DockerHub username | Image push |
+| `DOCKERHUB_TOKEN` | DockerHub access token | Image push |
+
+### Optional Secrets
+
+| Secret | Description | Required For |
+|--------|-------------|--------------|
+| `GHCR_TOKEN` | GitHub Container Registry | Push to ghcr.io |
+| `SIGNING_KEY` | GPG key for signing | Binary signing |
+
+### Setting Up Secrets
+
+1. Go to Repository → Settings → Secrets and variables → Actions
+2. Add `DOCKERHUB_USERNAME` with your DockerHub username
+3. Add `DOCKERHUB_TOKEN` with a DockerHub access token (not password)
+
+```bash
+# Generate DockerHub token at:
+# https://hub.docker.com/settings/security → New Access Token
+```
+
+## 6. Version Strategy
+
+### Semantic Versioning
+
+```
+v<MAJOR>.<MINOR>.<PATCH>[-<prerelease>]
+
+Examples:
+  v1.0.0        - Stable release
+  v1.1.0        - Minor feature release
+  v2.0.0        - Major release (breaking changes)
+  v1.0.0-rc.1   - Release candidate
+  v1.0.0-beta.1 - Beta release
+```
+
+### Version Sources
+
+| Source | Priority | Use Case |
+|--------|----------|----------|
+| Git tag | 1 (highest) | Release builds |
+| VERSION file | 2 | Development builds |
+| Git SHA | 3 (fallback) | PR builds |
+
+### Tagging Process
+
+```bash
+# Create and push a release tag
+git tag -a v1.0.0 -m "Release v1.0.0: Feature description"
+git push origin v1.0.0
+
+# This triggers the release workflow
+```
+
+## 7. Multi-Architecture Support
+
+### Docker Buildx Configuration
+
+```yaml
+# Uses docker/build-push-action with QEMU for cross-compilation
+platforms: linux/amd64,linux/arm64
+```
+
+### Go Cross-Compilation
+
+```yaml
+# Build matrix for Go binaries
+strategy:
+  matrix:
+    include:
+      - goos: linux
+        goarch: amd64
+      - goos: linux
+        goarch: arm64
+```
+
+### Architecture Detection
+
+| Platform | Docker Platform | Go GOOS/GOARCH |
+|----------|-----------------|----------------|
+| x86_64 Linux | linux/amd64 | linux/amd64 |
+| ARM64 Linux | linux/arm64 | linux/arm64 |
+| Raspberry Pi 4 | linux/arm64 | linux/arm64 |
+| Apple M1/M2 | linux/arm64 | darwin/arm64 |
+
+## 8. Workflow Files
+
+### Directory Structure
+
+```
+.github/
+└── workflows/
+    ├── ci.yml              # PR and push builds
+    ├── release.yml         # Release workflow
+    └── cleanup.yml         # (optional) Clean old artifacts
+```
+
+### CI Workflow Jobs
+
+| Job | Runs On | Purpose |
+|-----|---------|---------|
+| `lint` | ubuntu-latest | Go linting with golangci-lint |
+| `test` | ubuntu-latest | Go unit tests |
+| `build-go` | ubuntu-latest | Build Go binaries (gateway, agent) |
+| `build-frontend` | ubuntu-latest | Build Next.js frontend |
+| `docker-build` | ubuntu-latest | Test Docker builds (no push) |
+
+### Release Workflow Jobs
+
+| Job | Runs On | Purpose |
+|-----|---------|---------|
+| `build-binaries` | ubuntu-latest | Cross-compile Go binaries |
+| `build-push-images` | ubuntu-latest | Build and push Docker images |
+| `create-release` | ubuntu-latest | Create GitHub release with artifacts |
+
+## 9. Release Process
+
+### Automated Release Flow
+
+```
+1. Developer creates tag:
+   git tag -a v1.0.0 -m "Release v1.0.0"
+   git push origin v1.0.0
+
+2. GitHub Actions triggered:
+   - Builds binaries for all architectures
+   - Builds Docker images for all architectures
+   - Pushes images to DockerHub
+   - Creates GitHub Release
+   - Uploads binary artifacts
+   - Generates checksums
+
+3. Artifacts available:
+   - DockerHub: hellodk/avika-gateway:v1.0.0
+   - DockerHub: hellodk/avika-frontend:v1.0.0
+   - DockerHub: hellodk/avika-agent:v1.0.0
+   - GitHub Release: gateway-linux-amd64, gateway-linux-arm64
+   - GitHub Release: agent-linux-amd64, agent-linux-arm64
+   - GitHub Release: checksums.txt
+```
+
+### Manual Release (workflow_dispatch)
+
+```bash
+# Trigger via GitHub UI or CLI
+gh workflow run release.yml -f version=v1.0.0
+```
+
+### Release Checklist
+
+- [ ] All tests passing on master
+- [ ] CHANGELOG updated (if maintained)
+- [ ] Version bumped in VERSION file
+- [ ] Tag created with release notes
+- [ ] Verify DockerHub images published
+- [ ] Verify GitHub Release created
+- [ ] Verify binary checksums
+
+## 10. Cost & Performance Considerations
+
+### GitHub Actions Minutes
+
+| Workflow | Estimated Time | Frequency |
+|----------|----------------|-----------|
+| CI (PR) | ~5-10 min | Per PR |
+| CI (push) | ~5-10 min | Per push to master |
+| Release | ~15-20 min | Per release tag |
+
+### Optimization Strategies
+
+1. **Caching**
+   - Go modules cache
+   - Docker layer cache
+   - npm/pnpm cache for frontend
+
+2. **Parallel Jobs**
+   - Build binaries in parallel matrix
+   - Build Docker images in parallel
+
+3. **Conditional Builds**
+   - Skip frontend build if no frontend changes
+   - Skip agent build if no agent changes
+
+### Docker Image Sizes (estimated)
+
+| Image | Estimated Size | Base |
+|-------|----------------|------|
+| Gateway | ~30-50 MB | Alpine/Distroless |
+| Frontend | ~100-150 MB | Node Alpine |
+| Agent | ~20-40 MB | Alpine/Distroless |
+
+---
+
+## Confirmed Decisions
+
+| Decision | Choice |
+|----------|--------|
+| **Docker Registry** | DockerHub only |
+| **Linux Architectures** | amd64, arm64 |
+| **macOS Architectures** | amd64 (Intel), arm64 (Apple Silicon) |
+| **Windows** | Not supported |
+| **Image Tags** | `v1.0.0`, `latest`, `sha-abc1234` |
+| **Release Notes** | Auto-generated with user review |
+| **Helm Chart** | Included in releases |
+| **Version Source** | VERSION file (auto-bumped) |
+
+## Version Auto-Bump Strategy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Release Trigger                          │
+│                                                             │
+│  Manual trigger with bump type:                             │
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐                     │
+│  │  patch  │  │  minor  │  │  major  │                     │
+│  │ 1.0.0 → │  │ 1.0.0 → │  │ 1.0.0 → │                     │
+│  │ 1.0.1   │  │ 1.1.0   │  │ 2.0.0   │                     │
+│  └─────────┘  └─────────┘  └─────────┘                     │
+│                                                             │
+│  Workflow:                                                  │
+│  1. Read current version from VERSION file                  │
+│  2. Bump version based on type (patch/minor/major)          │
+│  3. Update VERSION file                                     │
+│  4. Commit version bump                                     │
+│  5. Create git tag                                          │
+│  6. Build artifacts                                         │
+│  7. Push to DockerHub                                       │
+│  8. Create GitHub Release (draft for review)                │
+│  9. User reviews and publishes                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+*Last updated: February 2026*


### PR DESCRIPTION
## Summary

Adds complete CI/CD pipeline using GitHub Actions for automated builds and releases.

## CI Workflow (`ci.yml`)

Triggered on PRs and pushes to master:
- Go linting with golangci-lint
- Go unit tests with coverage
- Build gateway and agent binaries
- Build frontend
- Test Docker image builds (no push)

## Release Workflow (`release.yml`)

Triggered manually via workflow_dispatch:
- Auto-bump VERSION file (patch/minor/major)
- Build binaries for multiple architectures:
  - linux/amd64, linux/arm64
  - darwin/amd64, darwin/arm64 (macOS)
- Build and push Docker images to DockerHub:
  - avika-gateway
  - avika-frontend
  - avika-agent
- Package Helm chart
- Create draft GitHub Release with:
  - Auto-generated release notes
  - Binary artifacts
  - Helm chart
  - SHA256 checksums

## Required Secrets

Add these to repository settings:
- `DOCKERHUB_TOKEN` - DockerHub access token

## Usage

```bash
# Trigger a patch release (1.0.0 -> 1.0.1)
gh workflow run release.yml -f bump_type=patch

# Trigger a minor release (1.0.0 -> 1.1.0)
gh workflow run release.yml -f bump_type=minor

# Trigger a major release (1.0.0 -> 2.0.0)
gh workflow run release.yml -f bump_type=major

# Create a pre-release (1.0.0 -> 1.0.1-rc.1)
gh workflow run release.yml -f bump_type=patch -f prerelease=rc.1
```