### PR TITLE
fix: Add tag trigger to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@
 name: Release
 
 on:
+  # Trigger on version tags (v*.*.*)
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   # Manual trigger for releases
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
Added tag push trigger to Release workflow to ensure GitHub Actions indexes and displays it in the UI.

The workflow will now trigger on:
- Manual dispatch (workflow_dispatch)
- Tag pushes matching `v*.*.*`
- Being called from other workflows (workflow_call)

Made with [Cursor](https://cursor.com)