### PR TITLE
fix: Add write permissions to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: ''
 
+# Grant permissions for pushing commits and tags
+permissions:
+  contents: write
+  packages: write
+
 env:
   GO_VERSION: '1.23'
   NODE_VERSION: '20'


### PR DESCRIPTION
Add permissions block to allow GitHub Actions to push version commits and tags.

Made with [Cursor](https://cursor.com)