### PR TITLE
fix: Allow JSON files to bypass auth middleware for map data

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -42,9 +42,9 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
-     * - public files (images, etc.)
+     * - public files (images, json, etc.)
      */
     "/",
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).+)",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|json|ico)$).+)",
   ],
 };


### PR DESCRIPTION
The world map JSON file was being blocked by the auth middleware, causing the geo page map to not render. This fix allows .json files to bypass authentication.

Made with [Cursor](https://cursor.com)