### PR TITLE
feat(reports): Add PDF download API endpoint

### DIFF
--- a/frontend/src/app/api/reports/download/route.ts
+++ b/frontend/src/app/api/reports/download/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { getAgentServiceClient } from '@/lib/grpc-client';
+
+export async function GET(req: Request) {
+    const { searchParams } = new URL(req.url);
+    const start = parseInt(searchParams.get('start') || '0');
+    const end = parseInt(searchParams.get('end') || '0');
+    const agentIds = searchParams.get('agent_ids')?.split(',').filter(Boolean) || [];
+
+    const client = getAgentServiceClient();
+
+    return new Promise<NextResponse>((resolve) => {
+        client.DownloadReport({
+            start_time: start,
+            end_time: end,
+            agent_ids: agentIds,
+            report_type: 'summary',
+        }, (err: any, response: any) => {
+            if (err) {
+                console.error('gRPC DownloadReport Error:', err);
+                return resolve(NextResponse.json({ error: err.message }, { status: 500 }));
+            }
+
+            if (!response?.content) {
+                return resolve(NextResponse.json({ error: 'No PDF content returned' }, { status: 500 }));
+            }
+
+            const pdfBuffer = Buffer.from(response.content);
+            const fileName = response.file_name || `avika-report-${Date.now()}.pdf`;
+
+            return resolve(new NextResponse(pdfBuffer, {
+                status: 200,
+                headers: {
+                    'Content-Type': response.content_type || 'application/pdf',
+                    'Content-Disposition': `attachment; filename="${fileName}"`,
+                    'Content-Length': pdfBuffer.length.toString(),
+                },
+            }));
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- Adds `/api/reports/download` endpoint for PDF report generation
- Enables the PDF export button on the Reports page

## Changes
- New API route that calls backend `DownloadReport` gRPC method
- Returns PDF as binary attachment with proper headers
- Supports time range filtering via `start`/`end` query params

## Test Plan
- [ ] Navigate to Reports page (`/avika/reports`)
- [ ] Click "Generate" to create a report
- [ ] Click "PDF" button to download
- [ ] Verify PDF contains charts and visual KPIs


Made with [Cursor](https://cursor.com)