### PR TITLE
fix(ci): Use PAT token to bypass branch protection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use RELEASE_TOKEN (PAT) to bypass branch protection rules
+          # Falls back to GITHUB_TOKEN if RELEASE_TOKEN is not set
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary
- Updated release workflow to use `RELEASE_TOKEN` (PAT) instead of default `GITHUB_TOKEN`
- This allows the workflow to push version bump commits to protected `master` branch

## Setup Required
After merging this PR:
1. Create a **Fine-grained Personal Access Token** at GitHub Settings → Developer settings → Personal access tokens
   - Repository access: Select this repository
   - Permissions: `Contents` → Read and write
2. Add the token as a repository secret named `RELEASE_TOKEN`
   - Go to repo Settings → Secrets and variables → Actions → New repository secret

## Why This Is Needed
- The `master` branch is protected with a rule requiring changes through PRs
- The release workflow needs to push version bump commits directly to master
- `GITHUB_TOKEN` respects branch protection, but PATs can bypass it if configured


Made with [Cursor](https://cursor.com)