### PR TITLE
feat(ui): Add new themes and improve accessibility

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -16,7 +16,9 @@ import {
     Sparkles,
     ChevronDown,
     Loader2,
-    Trash2
+    Trash2,
+    BarChart3,
+    Building2
 } from "lucide-react";
 import { useTheme } from "@/lib/theme-provider";
 import { themes, ThemeName } from "@/lib/themes";
@@ -28,11 +30,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { toast } from "sonner";
 
-const themeIcons = {
+const themeIcons: Record<string, typeof Moon> = {
     dark: Moon,
     light: Sun,
     solarized: Sparkles,
     nord: Sparkles,
+    nginxOne: Building2,
+    grafanaDark: BarChart3,
 };
 
 export default function SettingsPage() {

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -418,11 +418,12 @@ function NavLink({ href, icon, label, pathname, collapsed, badge, badgeColor = "
         ? pathname === "/" 
         : pathname.startsWith(href) && (href !== "/" || pathname === "/");
     
-    const badgeColorClasses: Record<string, string> = {
-        blue: "bg-blue-500/20 text-blue-400",
-        purple: "bg-purple-500/20 text-purple-400",
-        green: "bg-emerald-500/20 text-emerald-400",
-        amber: "bg-amber-500/20 text-amber-400",
+    // Theme-aware badge colors using CSS variables
+    const badgeStyles: Record<string, React.CSSProperties> = {
+        blue: { background: "rgba(var(--theme-primary), 0.2)", color: "rgb(var(--theme-primary))" },
+        purple: { background: "rgba(139, 92, 246, 0.2)", color: "rgb(139, 92, 246)" },
+        green: { background: "rgba(var(--theme-success), 0.2)", color: "rgb(var(--theme-success))" },
+        amber: { background: "rgba(var(--theme-warning), 0.2)", color: "rgb(var(--theme-warning))" },
     };
 
     return (
@@ -430,8 +431,8 @@ function NavLink({ href, icon, label, pathname, collapsed, badge, badgeColor = "
             href={href}
             className={`flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-all ${collapsed ? 'justify-center' : ''}`}
             style={isActive ? {
-                background: "rgba(59, 130, 246, 0.1)",
-                color: "rgb(59, 130, 246)",
+                background: "rgba(var(--theme-primary), 0.1)",
+                color: "rgb(var(--theme-primary))",
             } : {
                 color: "rgb(var(--theme-text-muted))",
             }}
@@ -442,7 +443,10 @@ function NavLink({ href, icon, label, pathname, collapsed, badge, badgeColor = "
                 <>
                     <span className="flex-1">{label}</span>
                     {badge && (
-                        <Badge className={`text-[10px] px-1.5 py-0 ${badgeColorClasses[badgeColor]}`}>
+                        <Badge 
+                            className="text-[10px] px-1.5 py-0"
+                            style={badgeStyles[badgeColor] || badgeStyles.blue}
+                        >
                             {badge}
                         </Badge>
                     )}

--- a/frontend/src/lib/chart-colors.ts
+++ b/frontend/src/lib/chart-colors.ts
@@ -5,7 +5,7 @@
  * that adapt to the current theme while maintaining WCAG AA contrast ratios.
  */
 
-export type ThemeMode = 'dark' | 'light' | 'solarized' | 'nord';
+export type ThemeMode = 'dark' | 'light' | 'solarized' | 'nord' | 'nginxOne' | 'grafanaDark';
 
 export interface ChartColorPalette {
     // Grid and axes
@@ -175,36 +175,128 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
             tooltipBorder: '#4c566a', // Polar Night 3
             
             success: '#a3be8c',       // Nord green
-            warning: '#ebcb8b',       // Nord yellow
+            warning: '#ffb74d',       // FIXED: Brighter amber for visibility
             error: '#bf616a',         // Nord red
             info: '#88c0d0',          // Nord frost
             
             status2xx: '#a3be8c',
             status3xx: '#88c0d0',
-            status4xx: '#ebcb8b',
+            status4xx: '#ffb74d',     // FIXED: Brighter amber
             status5xx: '#bf616a',
             
             connectionActive: '#88c0d0',
             connectionReading: '#a3be8c',
-            connectionWriting: '#ebcb8b',
+            connectionWriting: '#ffb74d',  // FIXED: Brighter amber
             connectionWaiting: '#b48ead',
             
             cpu: '#b48ead',           // Nord purple
-            memory: '#ebcb8b',
+            memory: '#ffb74d',        // FIXED: Brighter amber
             networkRx: '#a3be8c',
             networkTx: '#88c0d0',
             
             latencyP50: '#8fbcbb',    // Nord frost 0
-            latencyP95: '#ebcb8b',
+            latencyP95: '#ffb74d',    // FIXED: Brighter amber
             latencyP99: '#bf616a',
             
             series: [
                 '#88c0d0',
                 '#a3be8c',
-                '#ebcb8b',
+                '#ffb74d',
                 '#b48ead',
                 '#bf616a',
                 '#8fbcbb',
+            ],
+        };
+    }
+    
+    // NGINX One - Clean professional light theme (matches reference dashboard)
+    if (theme === 'nginxOne') {
+        return {
+            grid: 'rgba(0, 0, 0, 0.06)',
+            axis: '#64748b',          // slate-500
+            axisLabel: '#475569',     // slate-600
+            
+            tooltipBg: '#ffffff',
+            tooltipText: '#0f172a',   // slate-900
+            tooltipBorder: '#e2e8f0', // slate-200
+            
+            success: '#10b981',       // emerald-500
+            warning: '#f59e0b',       // amber-500
+            error: '#ef4444',         // red-500
+            info: '#228be6',          // NGINX blue
+            
+            status2xx: '#10b981',     // emerald-500
+            status3xx: '#228be6',     // NGINX blue
+            status4xx: '#f59e0b',     // amber-500
+            status5xx: '#ef4444',     // red-500
+            
+            connectionActive: '#228be6',
+            connectionReading: '#10b981',
+            connectionWriting: '#f59e0b',
+            connectionWaiting: '#8b5cf6',
+            
+            cpu: '#6366f1',           // indigo-500
+            memory: '#f59e0b',
+            networkRx: '#10b981',
+            networkTx: '#228be6',
+            
+            latencyP50: '#10b981',
+            latencyP95: '#f59e0b',
+            latencyP99: '#ef4444',
+            
+            series: [
+                '#228be6',  // NGINX blue
+                '#10b981',  // emerald-500
+                '#f59e0b',  // amber-500
+                '#8b5cf6',  // violet-500
+                '#ec4899',  // pink-500
+                '#06b6d4',  // cyan-500
+            ],
+        };
+    }
+    
+    // Grafana Dark - Matches Grafana's dark theme
+    if (theme === 'grafanaDark') {
+        return {
+            grid: 'rgba(255, 255, 255, 0.1)',
+            axis: '#ccccdc',
+            axisLabel: '#ccccdc',
+            
+            tooltipBg: '#1f1f1f',
+            tooltipText: '#ccccdc',
+            tooltipBorder: '#2c323a',
+            
+            success: '#73bf69',       // Grafana green
+            warning: '#fab005',       // Grafana yellow
+            error: '#f2495c',         // Grafana red
+            info: '#3274d9',          // Grafana blue
+            
+            status2xx: '#73bf69',
+            status3xx: '#3274d9',
+            status4xx: '#fab005',
+            status5xx: '#f2495c',
+            
+            connectionActive: '#3274d9',
+            connectionReading: '#73bf69',
+            connectionWriting: '#fab005',
+            connectionWaiting: '#8f3bb8',  // Grafana purple
+            
+            cpu: '#8f3bb8',
+            memory: '#fab005',
+            networkRx: '#73bf69',
+            networkTx: '#3274d9',
+            
+            latencyP50: '#73bf69',
+            latencyP95: '#fab005',
+            latencyP99: '#f2495c',
+            
+            series: [
+                '#3274d9',  // Grafana blue
+                '#73bf69',  // Grafana green
+                '#fab005',  // Grafana yellow
+                '#8f3bb8',  // Grafana purple
+                '#f2495c',  // Grafana red
+                '#56a3ff',  // Grafana light blue
             ],
         };
     }
@@ -266,6 +358,8 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
 export function getChartColorsForTheme(themeName: string): ChartColorPalette {
     const normalizedTheme = themeName?.toLowerCase() || 'dark';
     
+    if (normalizedTheme === 'nginxone') return getChartColors('nginxOne');
+    if (normalizedTheme === 'grafanadark') return getChartColors('grafanaDark');
     if (normalizedTheme.includes('light')) return getChartColors('light');
     if (normalizedTheme.includes('solarized')) return getChartColors('solarized');
     if (normalizedTheme.includes('nord')) return getChartColors('nord');

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -32,10 +32,9 @@ export const themes = {
         background: "0 43 54", // Base03
         surface: "7 54 66", // Base02
         surfaceLight: "88 110 117", // Base01
-        // FIXED: Improved contrast - using Base1/Base2 for better WCAG compliance
         text: "238 232 213", // Base2 - Cream white for maximum contrast
         textMuted: "147 161 161", // Base1 - Brighter secondary text
-        textDim: "131 148 150", // Base0 - Original text color for tertiary
+        textDim: "157 171 171", // FIXED: Brighter than Base0 for WCAG AA (4.5:1 contrast)
         primary: "38 139 210", // Blue
         success: "133 153 0", // Green
         warning: "203 75 22", // Orange (more visible than yellow)
@@ -52,9 +51,39 @@ export const themes = {
         textDim: "216 222 233", // Snow Storm 0
         primary: "136 192 208", // Frost 3
         success: "163 190 140", // Aurora Green
-        warning: "235 203 139", // Aurora Yellow
+        warning: "255 183 77", // FIXED: Brighter amber/orange for better visibility
         error: "191 97 106", // Aurora Red
         border: "76 86 106", // Polar Night 3 - brighter for visibility
+    },
+    // NGINX One - Clean professional light theme (matches nginx-one-dashboard reference)
+    nginxOne: {
+        name: "NGINX One",
+        background: "250 250 252", // Near white with slight blue tint
+        surface: "255 255 255", // Pure white cards
+        surfaceLight: "243 244 246", // Gray-100 hover states
+        text: "15 23 42", // Slate-900 - maximum readability
+        textMuted: "71 85 105", // Slate-600 - good secondary contrast
+        textDim: "100 116 139", // Slate-500 - tertiary text
+        primary: "34 139 230", // NGINX Blue
+        success: "16 185 129", // Emerald-500
+        warning: "245 158 11", // Amber-500
+        error: "239 68 68", // Red-500
+        border: "226 232 240", // Slate-200 - subtle borders
+    },
+    // Grafana Dark - Matches Grafana's dark theme (reference image.png)
+    grafanaDark: {
+        name: "Grafana Dark",
+        background: "17 18 23", // Grafana dark background
+        surface: "24 27 31", // Grafana panel background
+        surfaceLight: "32 34 38", // Hover state
+        text: "204 204 220", // Grafana main text
+        textMuted: "138 138 153", // Grafana secondary text
+        textDim: "108 108 121", // Grafana dim text
+        primary: "50 116 217", // Grafana blue
+        success: "115 191 105", // Grafana green
+        warning: "250 176 5", // Grafana yellow/amber
+        error: "242 73 92", // Grafana red
+        border: "44 50 58", // Grafana panel border
     },
 } as const;
 


### PR DESCRIPTION
## Summary
- Add **NGINX One** theme - professional light theme matching nginx-one-dashboard reference
- Add **Grafana Dark** theme - matches Grafana's dark theme styling
- Fix **Solarized textDim** contrast for WCAG AA compliance (4.5:1 ratio)
- Fix **Nord warning** color visibility with brighter amber
- Make navigation active state **theme-aware** using CSS variables
- Make badge colors **theme-aware** for consistent appearance across themes
- Add theme icons (Building2, BarChart3) for new themes in settings

## Changes
- `frontend/src/lib/themes.ts` - Added 2 new theme definitions, fixed contrast issues
- `frontend/src/lib/chart-colors.ts` - Added chart colors for new themes
- `frontend/src/app/settings/page.tsx` - Added theme icons for dropdown
- `frontend/src/components/dashboard-layout.tsx` - Made NavLink and badges theme-aware

## Test plan
- [ ] Switch to each theme in Settings and verify appearance
- [ ] Check navigation sidebar active state colors across all themes
- [ ] Verify badge colors are visible across themes
- [ ] Test on NGINX One theme - verify readability on light background
- [ ] Test on Grafana Dark theme - verify colors match Grafana styling
- [ ] Verify Solarized text contrast is improved
- [ ] Verify Nord warning colors are visible


Made with [Cursor](https://cursor.com)