### PR TITLE
refactor(ui): Rename themes to non-proprietary names

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -17,7 +17,7 @@ import {
     ChevronDown,
     Loader2,
     Trash2,
-    BarChart3,
+    Eclipse,
     Building2
 } from "lucide-react";
 import { useTheme } from "@/lib/theme-provider";
@@ -35,8 +35,8 @@ const themeIcons: Record<string, typeof Moon> = {
     light: Sun,
     solarized: Sparkles,
     nord: Sparkles,
-    nginxOne: Building2,
-    grafanaDark: BarChart3,
+    corporate: Building2,
+    midnight: Eclipse,
 };
 
 export default function SettingsPage() {

--- a/frontend/src/lib/chart-colors.ts
+++ b/frontend/src/lib/chart-colors.ts
@@ -5,7 +5,7 @@
  * that adapt to the current theme while maintaining WCAG AA contrast ratios.
  */
 
-export type ThemeMode = 'dark' | 'light' | 'solarized' | 'nord' | 'nginxOne' | 'grafanaDark';
+export type ThemeMode = 'dark' | 'light' | 'solarized' | 'nord' | 'corporate' | 'midnight';
 
 export interface ChartColorPalette {
     // Grid and axes
@@ -56,7 +56,7 @@ export interface ChartColorPalette {
  * All colors are chosen to meet WCAG AA contrast requirements
  */
 export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
-    const isDark = theme !== 'light';
+    const isDark = theme !== 'light' && theme !== 'corporate';
     
     // Common colors that work in both modes (with slight adjustments)
     const baseColors = {
@@ -209,8 +209,8 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
         };
     }
     
-    // NGINX One - Clean professional light theme (matches reference dashboard)
-    if (theme === 'nginxOne') {
+    // Corporate - Clean professional light theme
+    if (theme === 'corporate') {
         return {
             grid: 'rgba(0, 0, 0, 0.06)',
             axis: '#64748b',          // slate-500
@@ -223,10 +223,10 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
             success: '#10b981',       // emerald-500
             warning: '#f59e0b',       // amber-500
             error: '#ef4444',         // red-500
-            info: '#228be6',          // NGINX blue
+            info: '#228be6',          // Professional blue
             
             status2xx: '#10b981',     // emerald-500
-            status3xx: '#228be6',     // NGINX blue
+            status3xx: '#228be6',     // Professional blue
             status4xx: '#f59e0b',     // amber-500
             status5xx: '#ef4444',     // red-500
             
@@ -245,7 +245,7 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
             latencyP99: '#ef4444',
             
             series: [
-                '#228be6',  // NGINX blue
+                '#228be6',  // Professional blue
                 '#10b981',  // emerald-500
                 '#f59e0b',  // amber-500
                 '#8b5cf6',  // violet-500
@@ -255,8 +255,8 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
         };
     }
     
-    // Grafana Dark - Matches Grafana's dark theme
-    if (theme === 'grafanaDark') {
+    // Midnight - Deep dark theme with rich colors
+    if (theme === 'midnight') {
         return {
             grid: 'rgba(255, 255, 255, 0.1)',
             axis: '#ccccdc',
@@ -266,10 +266,10 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
             tooltipText: '#ccccdc',
             tooltipBorder: '#2c323a',
             
-            success: '#73bf69',       // Grafana green
-            warning: '#fab005',       // Grafana yellow
-            error: '#f2495c',         // Grafana red
-            info: '#3274d9',          // Grafana blue
+            success: '#73bf69',       // Vibrant green
+            warning: '#fab005',       // Golden yellow
+            error: '#f2495c',         // Coral red
+            info: '#3274d9',          // Rich blue
             
             status2xx: '#73bf69',
             status3xx: '#3274d9',
@@ -279,7 +279,7 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
             connectionActive: '#3274d9',
             connectionReading: '#73bf69',
             connectionWriting: '#fab005',
-            connectionWaiting: '#8f3bb8',  // Grafana purple
+            connectionWaiting: '#8f3bb8',  // Purple
             
             cpu: '#8f3bb8',
             memory: '#fab005',
@@ -291,12 +291,12 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
             latencyP99: '#f2495c',
             
             series: [
-                '#3274d9',  // Grafana blue
-                '#73bf69',  // Grafana green
-                '#fab005',  // Grafana yellow
-                '#8f3bb8',  // Grafana purple
-                '#f2495c',  // Grafana red
-                '#56a3ff',  // Grafana light blue
+                '#3274d9',  // Rich blue
+                '#73bf69',  // Vibrant green
+                '#fab005',  // Golden yellow
+                '#8f3bb8',  // Purple
+                '#f2495c',  // Coral red
+                '#56a3ff',  // Light blue
             ],
         };
     }
@@ -358,8 +358,8 @@ export function getChartColors(theme: ThemeMode = 'dark'): ChartColorPalette {
 export function getChartColorsForTheme(themeName: string): ChartColorPalette {
     const normalizedTheme = themeName?.toLowerCase() || 'dark';
     
-    if (normalizedTheme === 'nginxone') return getChartColors('nginxOne');
-    if (normalizedTheme === 'grafanadark') return getChartColors('grafanaDark');
+    if (normalizedTheme === 'corporate') return getChartColors('corporate');
+    if (normalizedTheme === 'midnight') return getChartColors('midnight');
     if (normalizedTheme.includes('light')) return getChartColors('light');
     if (normalizedTheme.includes('solarized')) return getChartColors('solarized');
     if (normalizedTheme.includes('nord')) return getChartColors('nord');

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -55,35 +55,35 @@ export const themes = {
         error: "191 97 106", // Aurora Red
         border: "76 86 106", // Polar Night 3 - brighter for visibility
     },
-    // NGINX One - Clean professional light theme (matches nginx-one-dashboard reference)
-    nginxOne: {
-        name: "NGINX One",
+    // Corporate - Clean professional light theme
+    corporate: {
+        name: "Corporate",
         background: "250 250 252", // Near white with slight blue tint
         surface: "255 255 255", // Pure white cards
         surfaceLight: "243 244 246", // Gray-100 hover states
         text: "15 23 42", // Slate-900 - maximum readability
         textMuted: "71 85 105", // Slate-600 - good secondary contrast
         textDim: "100 116 139", // Slate-500 - tertiary text
-        primary: "34 139 230", // NGINX Blue
+        primary: "34 139 230", // Professional Blue
         success: "16 185 129", // Emerald-500
         warning: "245 158 11", // Amber-500
         error: "239 68 68", // Red-500
         border: "226 232 240", // Slate-200 - subtle borders
     },
-    // Grafana Dark - Matches Grafana's dark theme (reference image.png)
-    grafanaDark: {
-        name: "Grafana Dark",
-        background: "17 18 23", // Grafana dark background
-        surface: "24 27 31", // Grafana panel background
+    // Midnight - Deep dark theme with rich colors
+    midnight: {
+        name: "Midnight",
+        background: "17 18 23", // Deep dark background
+        surface: "24 27 31", // Panel background
         surfaceLight: "32 34 38", // Hover state
-        text: "204 204 220", // Grafana main text
-        textMuted: "138 138 153", // Grafana secondary text
-        textDim: "108 108 121", // Grafana dim text
-        primary: "50 116 217", // Grafana blue
-        success: "115 191 105", // Grafana green
-        warning: "250 176 5", // Grafana yellow/amber
-        error: "242 73 92", // Grafana red
-        border: "44 50 58", // Grafana panel border
+        text: "204 204 220", // Main text
+        textMuted: "138 138 153", // Secondary text
+        textDim: "108 108 121", // Dim text
+        primary: "50 116 217", // Rich blue
+        success: "115 191 105", // Vibrant green
+        warning: "250 176 5", // Golden yellow
+        error: "242 73 92", // Coral red
+        border: "44 50 58", // Panel border
     },
 } as const;
 


### PR DESCRIPTION
## Summary
- Rename "NGINX One" theme to "Corporate"
- Rename "Grafana Dark" theme to "Midnight"
- Update theme icons and references in settings page
- Update chart color mappings for renamed themes

## Changes
This removes proprietary names from the theme system while preserving all the same colors and styling.

| Old Name | New Name |
|----------|----------|
| NGINX One | Corporate |
| Grafana Dark | Midnight |

## Test Plan
- [ ] Verify themes appear correctly in settings dropdown
- [ ] Verify all theme colors render correctly
- [ ] Test switching between themes


Made with [Cursor](https://cursor.com)