### PR TITLE
fix: broken pages, nav reorg, local build/deploy, and UX tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ check-version:
 # Read VERSION only after confirming it exists
 VERSION = $(shell cat VERSION)
 
-docker-all: check-version docker-gateway docker-frontend
+docker-all: check-version docker-gateway docker-frontend docker-agent
 	@echo "$(GREEN)All Docker images built$(NC)"
 
 docker-gateway: check-version
@@ -275,6 +275,13 @@ docker-frontend: check-version
 		-f frontend/Dockerfile frontend/
 	@rm -f frontend/VERSION
 	@echo "$(GREEN)Frontend image built: $(DOCKER_REPO)/avika-frontend:$(VERSION)$(NC)"
+
+docker-agent: check-version
+	@echo "$(GREEN)Building agent Docker image v$(VERSION)...$(NC)"
+	docker build -t $(DOCKER_REPO)/avika-agent:$(VERSION) \
+		--build-arg VERSION=$(VERSION) \
+		-f cmd/agent/Dockerfile .
+	@echo "$(GREEN)Agent image built: $(DOCKER_REPO)/avika-agent:$(VERSION)$(NC)"
 
 docker-push: check-version docker-all
 	@echo "$(GREEN)Pushing Docker images v$(VERSION)...$(NC)"

--- a/deploy/helm/avika/templates/service.yaml
+++ b/deploy/helm/avika/templates/service.yaml
@@ -23,6 +23,13 @@ spec:
   {{- if and (eq (($component.service).type | default "ClusterIP") "LoadBalancer") (($component.service).loadBalancerIP) }}
   loadBalancerIP: {{ $component.service.loadBalancerIP }}
   {{- end }}
+  {{- /* Gateway uses in-memory session cache; sticky sessions ensure same pod gets same client */ -}}
+  {{- if eq $name "gateway" }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600
+  {{- end }}
   ports:
     {{- range $portName, $port := $component.ports }}
     - port: {{ $port.servicePort | default $port.containerPort }}

--- a/deploy/helm/avika/values.yaml
+++ b/deploy/helm/avika/values.yaml
@@ -196,8 +196,8 @@ components:
     enabled: true
     replicaCount: 1
     image:
-      repository: hellodk/gateway
-      tag: "0.1.93"  # AVIKA SERVICE: Update with app version
+      repository: hellodk/avika-gateway
+      tag: "latest"
       pullPolicy: Always
     terminationGracePeriodSeconds: 35
     
@@ -277,7 +277,7 @@ components:
     replicaCount: 1
     image:
       repository: hellodk/avika-frontend
-      tag: "0.1.93"  # AVIKA SERVICE: Update with app version
+      tag: "latest"
       pullPolicy: Always
     
     ports:

--- a/frontend/src/app/api/audit/route.ts
+++ b/frontend/src/app/api/audit/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getGatewayUrl } from "@/lib/gateway-url";
+
+const GATEWAY_URL = getGatewayUrl();
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+        const limit = searchParams.get("limit") || "100";
+        const queryString = new URLSearchParams({ limit }).toString();
+        const sessionCookie = request.cookies.get("avika_session")?.value;
+
+        const gatewayResponse = await fetch(`${GATEWAY_URL}/api/audit?${queryString}`, {
+            method: "GET",
+            headers: sessionCookie ? { Cookie: `avika_session=${sessionCookie}` } : {},
+            cache: "no-store",
+        });
+
+        const data = await gatewayResponse.json();
+        return NextResponse.json(data, { status: gatewayResponse.status });
+    } catch (error) {
+        console.error("Audit API error:", error);
+        return NextResponse.json({ error: "Failed to fetch audit logs" }, { status: 500 });
+    }
+}

--- a/frontend/src/app/api/waf/policies/[id]/route.ts
+++ b/frontend/src/app/api/waf/policies/[id]/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getGatewayUrl } from "@/lib/gateway-url";
+
+const GATEWAY_URL = getGatewayUrl();
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id } = await params;
+        const sessionCookie = request.cookies.get("avika_session")?.value;
+
+        const gatewayResponse = await fetch(`${GATEWAY_URL}/api/waf/policies/${id}`, {
+            method: "GET",
+            headers: sessionCookie ? { Cookie: `avika_session=${sessionCookie}` } : {},
+            cache: "no-store",
+        });
+
+        const data = await gatewayResponse.json();
+        return NextResponse.json(data, { status: gatewayResponse.status });
+    } catch (error) {
+        console.error("WAF policy API error:", error);
+        return NextResponse.json({ error: "Failed to fetch WAF policy" }, { status: 500 });
+    }
+}
+
+export async function PUT(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id } = await params;
+        const sessionCookie = request.cookies.get("avika_session")?.value;
+        const body = await request.json();
+
+        const gatewayResponse = await fetch(`${GATEWAY_URL}/api/waf/policies/${id}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                ...(sessionCookie ? { Cookie: `avika_session=${sessionCookie}` } : {}),
+            },
+            body: JSON.stringify(body),
+            cache: "no-store",
+        });
+
+        const data = await gatewayResponse.json();
+        return NextResponse.json(data, { status: gatewayResponse.status });
+    } catch (error) {
+        console.error("WAF policy API error:", error);
+        return NextResponse.json({ error: "Failed to update WAF policy" }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id } = await params;
+        const sessionCookie = request.cookies.get("avika_session")?.value;
+
+        const gatewayResponse = await fetch(`${GATEWAY_URL}/api/waf/policies/${id}`, {
+            method: "DELETE",
+            headers: sessionCookie ? { Cookie: `avika_session=${sessionCookie}` } : {},
+            cache: "no-store",
+        });
+
+        if (gatewayResponse.status === 204 || gatewayResponse.ok) {
+            return new NextResponse(null, { status: gatewayResponse.status });
+        }
+        const data = await gatewayResponse.json();
+        return NextResponse.json(data, { status: gatewayResponse.status });
+    } catch (error) {
+        console.error("WAF policy API error:", error);
+        return NextResponse.json({ error: "Failed to delete WAF policy" }, { status: 500 });
+    }
+}

--- a/frontend/src/app/api/waf/policies/route.ts
+++ b/frontend/src/app/api/waf/policies/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getGatewayUrl } from "@/lib/gateway-url";
+
+const GATEWAY_URL = getGatewayUrl();
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+    try {
+        const sessionCookie = request.cookies.get("avika_session")?.value;
+
+        const gatewayResponse = await fetch(`${GATEWAY_URL}/api/waf/policies`, {
+            method: "GET",
+            headers: sessionCookie ? { Cookie: `avika_session=${sessionCookie}` } : {},
+            cache: "no-store",
+        });
+
+        const data = await gatewayResponse.json();
+        return NextResponse.json(data, { status: gatewayResponse.status });
+    } catch (error) {
+        console.error("WAF policies API error:", error);
+        return NextResponse.json({ error: "Failed to fetch WAF policies" }, { status: 500 });
+    }
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const sessionCookie = request.cookies.get("avika_session")?.value;
+        const body = await request.json();
+
+        const gatewayResponse = await fetch(`${GATEWAY_URL}/api/waf/policies`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                ...(sessionCookie ? { Cookie: `avika_session=${sessionCookie}` } : {}),
+            },
+            body: JSON.stringify(body),
+            cache: "no-store",
+        });
+
+        const data = await gatewayResponse.json();
+        return NextResponse.json(data, { status: gatewayResponse.status });
+    } catch (error) {
+        console.error("WAF policies API error:", error);
+        return NextResponse.json({ error: "Failed to create WAF policy" }, { status: 500 });
+    }
+}

--- a/frontend/src/app/audit/page.tsx
+++ b/frontend/src/app/audit/page.tsx
@@ -35,8 +35,8 @@ export default function AuditPage() {
                     const data = await res.json();
                     setLogs(data || []);
                 } else {
-                    const errData = await res.json();
-                    setError(errData.message || "Failed to fetch audit logs");
+                    const errData = await res.json().catch(() => ({}));
+                    setError(errData.error || errData.message || "Failed to fetch audit logs");
                 }
             } catch (err) {
                 setError("Connection error");

--- a/frontend/src/app/observability/grafana/page.tsx
+++ b/frontend/src/app/observability/grafana/page.tsx
@@ -13,6 +13,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import Link from "next/link";
+import { useUserSettings } from "@/lib/user-settings";
 
 const DEFAULT_GRAFANA_URL = "http://monitoring-grafana.monitoring.svc.cluster.local";
 
@@ -80,17 +81,17 @@ export default function GrafanaPage() {
     const [grafanaUrl, setGrafanaUrl] = useState("");
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const { getGrafanaBaseUrl } = useUserSettings();
 
     useEffect(() => {
-        // Priority: localStorage > env var > default
-        const savedUrl = typeof window !== 'undefined' ? localStorage.getItem("grafana_url") : null;
-        const envUrl = process.env.NEXT_PUBLIC_GRAFANA_URL;
-        const url = savedUrl || envUrl || DEFAULT_GRAFANA_URL;
-
+        const url = getGrafanaBaseUrl()
+            || (typeof window !== "undefined" ? localStorage.getItem("grafana_url")?.trim() : null)
+            || process.env.NEXT_PUBLIC_GRAFANA_URL
+            || DEFAULT_GRAFANA_URL;
         setGrafanaUrl(url);
         setError(null);
         setIsLoading(false);
-    }, []);
+    }, [getGrafanaBaseUrl]);
 
     const buildIframeUrl = (dashboard: GrafanaDashboard) => {
         if (!grafanaUrl) return "";

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -9,12 +9,15 @@ import { Save, Check, Loader2 } from "lucide-react";
 import { useUserSettings } from "@/lib/user-settings";
 import { toast } from "sonner";
 
+import Link from "next/link";
 import { AppearanceSettings } from "@/components/settings/appearance-settings";
 import { IntegrationSettings } from "@/components/settings/integration-settings";
 import { DisplaySettings } from "@/components/settings/display-settings";
 import { TelemetrySettings } from "@/components/settings/telemetry-settings";
 import { AIEngineSettings } from "@/components/settings/ai-engine-settings";
 import { AgentManagement } from "@/components/settings/agent-management";
+import { Zap, Lock, ChevronRight } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function SettingsPage() {
     const { settings: userSettings, updateSettings, resetSettings } = useUserSettings();
@@ -155,6 +158,41 @@ export default function SettingsPage() {
             </div>
 
             <AppearanceSettings />
+
+            <div className="grid gap-4 md:grid-cols-2">
+                <Link href="/settings/llm">
+                    <Card className="hover:border-blue-500/50 transition-colors cursor-pointer h-full" style={{ background: "rgb(var(--theme-surface))", borderColor: "rgb(var(--theme-border))" }}>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium flex items-center gap-2" style={{ color: "rgb(var(--theme-text))" }}>
+                                <Zap className="h-4 w-4 text-amber-500" />
+                                LLM Settings
+                            </CardTitle>
+                            <ChevronRight className="h-4 w-4" style={{ color: "rgb(var(--theme-text-muted))" }} />
+                        </CardHeader>
+                        <CardContent>
+                            <CardDescription style={{ color: "rgb(var(--theme-text-muted))" }}>
+                                Configure AI providers (OpenAI, Anthropic, Ollama) for error analysis and recommendations.
+                            </CardDescription>
+                        </CardContent>
+                    </Card>
+                </Link>
+                <Link href="/waf">
+                    <Card className="hover:border-blue-500/50 transition-colors cursor-pointer h-full" style={{ background: "rgb(var(--theme-surface))", borderColor: "rgb(var(--theme-border))" }}>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium flex items-center gap-2" style={{ color: "rgb(var(--theme-text))" }}>
+                                <Lock className="h-4 w-4 text-purple-500" />
+                                WAF Policies
+                            </CardTitle>
+                            <ChevronRight className="h-4 w-4" style={{ color: "rgb(var(--theme-text-muted))" }} />
+                        </CardHeader>
+                        <CardContent>
+                            <CardDescription style={{ color: "rgb(var(--theme-text-muted))" }}>
+                                Manage Web Application Firewall rule sets and distribution across your NGINX fleet.
+                            </CardDescription>
+                        </CardContent>
+                    </Card>
+                </Link>
+            </div>
 
             <IntegrationSettings
                 grafanaUrl={grafanaUrl}

--- a/frontend/src/app/visitors/page.tsx
+++ b/frontend/src/app/visitors/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -113,7 +114,7 @@ export default function VisitorsPage() {
   const fetchData = async () => {
     setLoading(true);
     try {
-      const response = await fetch(`/avika/api/visitor-analytics?timeWindow=${timeWindow}`);
+      const response = await apiFetch(`/api/visitor-analytics?timeWindow=${timeWindow}`);
       const json = await response.json();
       setData(json);
     } catch (error) {
@@ -150,7 +151,6 @@ export default function VisitorsPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Visitor Analytics</h1>
-          <p className="text-muted-foreground">GoAccess-style traffic analysis</p>
         </div>
         <Select value={timeWindow} onValueChange={setTimeWindow}>
           <SelectTrigger className="w-[180px] px-3 py-2 border rounded-md bg-background">

--- a/frontend/src/components/breadcrumb.tsx
+++ b/frontend/src/components/breadcrumb.tsx
@@ -18,7 +18,7 @@ const routeLabels: Record<string, string> = {
     provisions: "Provisions",
     analytics: "Analytics",
     traces: "Traces",
-    visitors: "Visitors",
+    visitors: "Visitor Analytics",
     geo: "Geo Analytics",
     observability: "Observability",
     grafana: "Grafana",

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -61,9 +61,9 @@ const NAV_SECTIONS: NavSection[] = [
         items: [
             { href: "/analytics", icon: <BarChart2 />, label: "Analytics" },
             { href: "/analytics/traces", icon: <GitBranch />, label: "Traces" },
-            { href: "/visitors", icon: <User />, label: "Visitors", badge: "New", badgeColor: "green" },
-            { href: "/geo", icon: <Globe />, label: "Geo Analytics", badge: "New", badgeColor: "green" },
-            { href: "/observability/grafana", icon: <LineChart />, label: "Grafana", badge: "New", badgeColor: "purple" },
+            { href: "/visitors", icon: <User />, label: "Visitor Analytics" },
+            { href: "/geo", icon: <Globe />, label: "Geo Analytics" },
+            { href: "/observability/grafana", icon: <LineChart />, label: "Grafana" },
             { href: "/alerts", icon: <ShieldAlert />, label: "Alerts" },
         ]
     },
@@ -78,9 +78,15 @@ const NAV_SECTIONS: NavSection[] = [
         title: "Admin",
         items: [
             { href: "/audit", icon: <ShieldAlert />, label: "Audit Logs" },
-            { href: "/waf", icon: <Lock />, label: "WAF Policies", badge: "New", badgeColor: "purple" },
-            { href: "/settings/llm", icon: <Zap />, label: "LLM" },
+        ],
+    },
+    {
+        title: "Settings",
+        items: [
+            { href: "/settings", icon: <Settings />, label: "General" },
             { href: "/settings/integrations", icon: <Globe />, label: "Integrations" },
+            { href: "/settings/llm", icon: <Zap />, label: "LLM" },
+            { href: "/waf", icon: <Lock />, label: "WAF Policies" },
         ],
     },
 ];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,7 +22,9 @@ export async function apiFetch(
 
   // Prepend base path if the path starts with /
   const url = path.startsWith("/") ? `${BASE_PATH}${path}` : path;
-  return fetch(url, options);
+  // Always send credentials (cookies) so session is forwarded to API routes
+  const opts = { ...options, credentials: "include" as RequestCredentials };
+  return fetch(url, opts);
 }
 
 /**


### PR DESCRIPTION
- Add API proxy routes for WAF policies and Audit logs (gateway auth)
- Add session affinity for gateway service (in-memory sessions)
- apiFetch: send credentials so session cookie is included
- Visitors: use apiFetch for visitor-analytics; remove GoAccess tagline
- Grafana: use useUserSettings().getGrafanaBaseUrl()
- Settings: add LLM and WAF cards; move WAF/LLM under Settings nav
- Nav: Settings section (General, Integrations, LLM, WAF); Admin = Audit only
- Visitor Analytics label in breadcrumb; Observability cleanup
- Helm: gateway/frontend use latest + pullPolicy Always in values
- Makefile: add docker-agent to docker-all for local amd64 build