### PR TITLE
feat: Settings tabs for LLM, WAF, SSO, LDAP, SAML + System UX preview

### DIFF
--- a/docs/UX-REDESIGN-SYSTEM-DASHBOARD.md
+++ b/docs/UX-REDESIGN-SYSTEM-DASHBOARD.md
@@ -1,0 +1,229 @@
+# System Dashboard UX Redesign Plan
+
+**Audience:** DevOps / SRE  
+**Page:** System (infrastructure & agent fleet) — *referred to as "Settings" in some contexts; redesign targets the observability dashboard that shows agents, uptime, and infrastructure health.*  
+**Goal:** Scanability in <3 seconds, clear operational state, minimal visual noise, progressive disclosure of detail.
+
+---
+
+## 1. Executive Summary
+
+The current System page presents the right data but with weak information architecture and heavy visual hierarchy. For an observability/infra dashboard, the primary question should be answered immediately: **Is the system healthy?** This document proposes a production-grade layout (Grafana/Datadog/Vercel-inspired) and lists concrete observations for Architects, Developers, and SREs to implement or triage.
+
+---
+
+## 2. Design Principles Applied
+
+| Principle | Current Issue | Target |
+|-----------|---------------|--------|
+| **Scanability** | Four large top cards + card-based infrastructure + dense table | One-line system overview; status-dense rows; thin tables |
+| **Operational state first** | Health buried below summary cards | Infrastructure health at top; big status indicators |
+| **Visual noise** | Many bordered cards, badges, icons per row | Soft grouping; dividers; fewer icons |
+| **Progressive disclosure** | Everything visible at once | Summary → Infrastructure → Fleet; hover for actions |
+
+---
+
+## 3. Proposed Layout (High-Level)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ SYSTEM HEALTH                                                            │
+│ Agents 8/8    Uptime 100%    Version v1.7.0                    [Refresh] │
+├──────────────────────────────────┬──────────────────────────────────────┤
+│ INFRASTRUCTURE                    │ AGENT FLEET                           │
+│ API Gateway      ● Healthy       │ Agent            Status    Ver   Seen │
+│ PostgreSQL       ● Healthy       │ ─────────────────────────────────────│
+│ ClickHouse       ● Healthy       │ ⎈ nginx-alpha    ● Online  1.7  2s   │
+│ Agent Network    ● 8 nodes       │ ⎈ nginx-beta     ● Online  1.7  1s   │
+│                                  │ 🖥 nginx-edge    ⚠ Update  0.19 3s   │
+│ (optional) TRAFFIC               │                                      │
+│ Requests/s  284  Err 0.03%  p95 18ms                                   │
+├──────────────────────────────────┴──────────────────────────────────────┤
+│ RECENT EVENTS (optional)                                                 │
+│ 12:41  nginx-beta connected    12:38  nginx-sidecar update available   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Specific Redesign Items
+
+### 4.1 Reduce Top Card Noise (P0)
+
+**Current:** Four full-width cards: Total Agents, Active Agents, Fleet Uptime, System Version.  
+**Proposed:** Single “System Overview” strip with inline metric chips (no card borders).
+
+- **Layout:** One row: `Agents 8/8` | `Uptime 100%` | `Version v1.7.0`
+- **Pattern reference:** Datadog / Linear / Vercel top metrics
+- **Implementation note:** Replace the 4-card grid with a single `<section>` and flex/grid of metric labels + values (large numbers, smaller labels).
+
+### 4.2 Promote Infrastructure Health to the Top (P0)
+
+**Current:** “Infrastructure Components” is below the summary cards; each component is a sub-card with icon, badge, description, version, latency.  
+**Proposed:** Infrastructure first (or immediately after one-line system overview). Status as simple rows with a single status indicator.
+
+- **Layout:** Section title “Infrastructure” (no “Components” / no long description). Rows: `Component name` + status dot + label (e.g. “● Healthy”).
+- **Optional:** Add latency/version as secondary text on the same line (e.g. “21ms”, “v1.7.0”) to avoid extra cards.
+- **Implementation:** Remove per-component cards; use a simple list or table-like rows with soft dividers.
+
+### 4.3 Two-Column Layout (P1)
+
+**Current:** Single column, long vertical scroll.  
+**Proposed:** Two columns on large viewports: left = system/infrastructure, right = agent fleet.
+
+- **Left column:** System overview line + Infrastructure list (+ optional micro metrics).
+- **Right column:** Agent fleet table (and optional recent events below).
+- **Benefit:** “System vs nodes” mental model; less scrolling; matches SRE expectations.
+
+### 4.4 Simplify the Agent Table (P0)
+
+**Current:** Columns Agent (with icon + hostname + truncated ID), Type (Kubernetes/VM badge), Version (with “Update available” badge), Status (badge), Last Seen, Actions (buttons).  
+**Proposed:**
+
+- **Columns:** Agent | Status | Version | Last Seen (drop explicit “Type” column by encoding type in agent name with icon).
+- **Agent column:** Icon (⎈ Pod / 🖥 VM) + hostname only; no truncated ID in default view; optional tooltip or second line for ID.
+- **Status:** Most visible element — larger semantic indicator (● ONLINE / ● DEGRADED / ● OFFLINE) with clear color (green / yellow / red / gray).
+- **Remove:** Heavy Kubernetes/VM badge as a separate column; redundant icon next to agent; always-visible action buttons.
+- **Actions:** Hover or row actions (e.g. “Open”, “Restart”, “Logs”, “Update” when applicable).
+
+### 4.5 Status as the Most Visible Element (P0)
+
+**Current:** Small green/red badges, low contrast.  
+**Proposed:**
+
+- Larger status indicator (dot + short label): e.g. “● ONLINE”, “● DEGRADED”, “● OFFLINE”.
+- Consistent semantics: green = healthy, yellow = degraded, red = down, gray = unknown.
+- Same treatment for infrastructure rows and agent rows.
+
+### 4.6 Remove Card Borders / Use Soft Grouping (P1)
+
+**Current:** Multiple Card components with borders around summary, infrastructure, and fleet.  
+**Proposed:**
+
+- Section titles with a subtle divider (or background) only; no heavy card borders.
+- “Section title + content” pattern; content can be list or table with minimal framing.
+- Reduces rectangles and visual clutter.
+
+### 4.7 Micro Metrics (P2)
+
+**Current:** No live traffic/activity metrics on this page.  
+**Proposed (optional):** Small “Traffic” or “Activity” block: Requests/s, Error rate, Latency p95 (from gateway or existing stats API). Keeps the dashboard “living” without adding big cards.
+
+### 4.8 Activity Stream (P2)
+
+**Current:** Page feels static.  
+**Proposed (optional):** “Recent events” strip: e.g. “12:41 nginx-beta connected”, “12:38 nginx-sidecar update available”. Improves operational context; can be collapsed by default on small screens.
+
+### 4.9 Visual Hierarchy (P1)
+
+**Current:** Similar font weights/sizes everywhere.  
+**Proposed:**
+
+- **Page title:** ~20px, bold.
+- **Section titles:** ~16px, semibold.
+- **Metric value (big number):** ~28px (or 24px) for “8/8”, “100%”, “v1.7.0”.
+- **Body/labels:** 14px, regular.
+- Ensures “big numbers” for key metrics and clear sectioning.
+
+### 4.10 Remove Redundant Labels (P1)
+
+**Current:** e.g. “Infrastructure Components” + “Core system services and their current status”.  
+**Proposed:** Single section title: “Infrastructure”. Same for “Agent Fleet” — drop long description or keep one short line if needed.
+
+### 4.11 Kubernetes / VM Distinction (P1)
+
+**Current:** “Type” column with badge (Kubernetes / VM).  
+**Proposed (choose one):**
+
+- **Option A (recommended):** Icon + label in Agent column: “⎈ nginx-alpha-dev”, “🖥 nginx-edge”. Legend: ⎈ = Pod, 🖥 = VM.
+- **Option B:** Subtext under hostname: “k8s / pod / eu-west-1” vs “vm / aws / us-east-1”.
+- **Option C:** Small muted pill next to name: [K8S] / [VM] with subtle color.
+
+---
+
+## 5. Observations for Architect / Developer / SRE
+
+These are actionable notes for implementation and product decisions.
+
+### 5.1 Architecture / Data
+
+| # | Observation | Owner | Notes |
+|---|-------------|--------|--------|
+| A1 | **Health and stats endpoints:** System page uses `/api/servers`, `/api/health`, `/api/ready`, `/api/stats`. Ensure a single “system overview” or “dashboard summary” API is not required for the new layout; current endpoints can still back the one-line metrics and infrastructure list. | Backend | If a dedicated “system summary” API is added later, it can return { agents_online, total, uptime_pct, version, components[] } to reduce client round-trips. |
+| A2 | **Real-time / polling:** Page polls every 10s. Consider WebSocket or SSE for “living” metrics and recent events to avoid stale data and improve “activity stream” UX. | Backend / Frontend | Optional; not blocking for layout redesign. |
+| A3 | **Agent “type” (Pod vs VM):** `agent.is_pod` is used for the Type column. Preserve this in API responses so the new Agent column (with icon) can display correctly. | Backend | No change required if field already exists. |
+
+### 5.2 Frontend / UI
+
+| # | Observation | Owner | Notes |
+|---|-------------|--------|--------|
+| F1 | **Replace 4-card grid** with one “System Overview” row (metrics only, no Card wrapper). | Frontend | Reuse or extend design tokens for “metric value” (e.g. 28px) and “metric label” (14px, muted). |
+| F2 | **Infrastructure block:** Refactor from 4 child cards to a single list/rows. Use status dot + label; optionally show version/latency inline. | Frontend | Reuse existing health data; change only presentation. |
+| F3 | **Two-column layout:** Use CSS Grid or Flex; left column ~40% (or min-width), right column 60% on lg breakpoint; stack on small screens. | Frontend | Ensure sidebar/nav does not break; test with project layout. |
+| F4 | **Agent table:** Reduce columns; merge Type into Agent (icon); make Status column prominent; replace always-visible action buttons with hover menu or icon button that reveals “Open / Restart / Logs / Update”. | Frontend | Accessibility: ensure hover actions are keyboard and screen-reader friendly (e.g. dropdown with focus trap). |
+| F5 | **Status semantics:** Centralize status → color/label/icon in a small util (e.g. `getStatusDisplay(status)`) and use for both infrastructure and agents. | Frontend | Keeps “Online/Degraded/Offline/Unknown” consistent. |
+| F6 | **Card removal:** Audit System page for all `<Card>` usages; replace with `<section>` + title + divider or light background where appropriate. | Frontend | Align with design system: consider a “Section” or “Block” component without border. |
+| F7 | **Micro metrics / Activity stream:** If implemented, need data source (e.g. `/api/stats` extended, or new endpoint). Frontend can reserve space and wire later. | Frontend / Backend | P2; can be placeholder or “Coming soon”. |
+
+### 5.3 SRE / Operations
+
+| # | Observation | Owner | Notes |
+|---|-------------|--------|--------|
+| S1 | **“Is the system healthy?” in <3s:** After redesign, validate with 2–3 SREs that the top of the page (system overview + infrastructure) answers this without scrolling. | SRE / Product | Acceptance criterion for P0. |
+| S2 | **Error state:** When health or agents fail to load, ensure error message is visible near the top (not buried below empty cards). | Frontend | Keep existing error alert; place it under the header / system overview. |
+| S3 | **Refresh:** Single “Refresh” control is sufficient; keep it in the system overview row. | Frontend | No change to behavior. |
+| S4 | **Agent actions:** Update / Restart / Logs must remain available (e.g. via hover or row menu) so SRE workflows are not broken. | Frontend | Ensure “Update” is discoverable when an agent has an update available. |
+
+### 5.4 Accessibility & QA
+
+| # | Observation | Owner | Notes |
+|---|-------------|--------|--------|
+| Q1 | **Status indicators:** Use `aria-label` and/or `role="status"` for “Healthy”, “Online”, “Degraded”, etc., and ensure color is not the only differentiator. | Frontend | Already partially done; extend to new status components. |
+| Q2 | **Hover actions:** When replacing action buttons with hover menu, ensure focus states and keyboard navigation (Enter/Space to open menu, arrows to move, Escape to close). | Frontend | Required for WCAG 2.1. |
+| Q3 | **Tables:** Agent table must remain a proper `<table>` (or equivalent with correct roles) for screen readers. | Frontend | Do not replace with divs only. |
+
+---
+
+## 6. Implementation Checklist (Suggested Order)
+
+- [ ] **P0 – Top metrics:** Replace 4 summary cards with one “System Overview” row (Agents, Uptime, Version).
+- [ ] **P0 – Infrastructure first:** Move infrastructure above or beside fleet; render as status rows (no sub-cards).
+- [ ] **P0 – Agent table:** Simplify columns (Agent with icon, Status, Version, Last Seen); make status prominent; remove Type column (encode in icon).
+- [ ] **P0 – Status visibility:** Implement consistent status component (dot + label, green/yellow/red/gray).
+- [ ] **P1 – Two-column layout:** Left = system + infrastructure; right = agent fleet; responsive stack.
+- [ ] **P1 – Soft grouping:** Remove card borders; use section titles + dividers/background only.
+- [ ] **P1 – Redundant copy:** Remove duplicate titles/descriptions (e.g. “Infrastructure” only).
+- [ ] **P1 – Typography:** Apply hierarchy (20px title, 16px section, 28px metric, 14px body).
+- [ ] **P2 – Hover actions:** Replace always-visible action buttons with row hover menu (Open, Restart, Logs, Update).
+- [ ] **P2 – Micro metrics:** Add Traffic/Activity block if backend supports (req/s, error rate, p95).
+- [ ] **P2 – Activity stream:** Add “Recent events” if backend/API supports.
+
+---
+
+## 7. Inspiration References
+
+- **Grafana:** Metrics-first top row; panels with minimal borders; high signal density.
+- **Datadog:** Status-dense rows; no big cards; clear operational signal per service.
+- **Vercel / Linear:** Few borders; typography hierarchy; soft separators.
+- **Kubernetes Dashboard:** Node list with type icons (e.g. pod vs node); compact table.
+
+---
+
+## 8. Sample UI
+
+A **preview route** is provided at **`/system/preview`** in the app. It implements the proposed layout with mock data so you can:
+
+- Compare current **`/system`** vs proposed **`/system/preview`**.
+- Validate scanability, hierarchy, and two-column layout before committing to full implementation.
+- Share with stakeholders for approval.
+
+After review, either:
+
+1. Replace the current System page with the new layout (and remove or repurpose `/system/preview`), or  
+2. Iterate on the preview and then merge the design into the main System page.
+
+---
+
+## 9. Settings Page (Clarification)
+
+This plan targets the **System** page (infrastructure + agent fleet). The **Settings** page (user preferences, integrations, LLM, WAF, etc.) is a different route. If you want similar “production-grade” treatment for Settings (e.g. less card noise, clearer sections), the same principles (soft grouping, clear hierarchy, reduced redundancy) can be applied there in a follow-up pass.

--- a/frontend/src/app/api/auth/sso-config/route.ts
+++ b/frontend/src/app/api/auth/sso-config/route.ts
@@ -15,13 +15,13 @@ export async function GET() {
         });
 
         if (!response.ok) {
-            return NextResponse.json({ oidc_enabled: false });
+            return NextResponse.json({ oidc_enabled: false, ldap_enabled: false, saml_enabled: false });
         }
 
         const data = await response.json();
         return NextResponse.json(data);
     } catch (error) {
         console.error('Error fetching SSO config:', error);
-        return NextResponse.json({ oidc_enabled: false });
+        return NextResponse.json({ oidc_enabled: false, ldap_enabled: false, saml_enabled: false });
     }
 }

--- a/frontend/src/app/settings/ldap/page.tsx
+++ b/frontend/src/app/settings/ldap/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Key, FileCode } from "lucide-react";
+
+const ENV_VARS = [
+    "LDAP_ENABLED",
+    "LDAP_URL",
+    "LDAP_BIND_DN",
+    "LDAP_BIND_PASSWORD",
+    "LDAP_BASE_DN",
+    "LDAP_USER_FILTER",
+    "LDAP_GROUP_FILTER",
+    "LDAP_DEFAULT_ROLE",
+    "LDAP_AUTO_PROVISION",
+    "LDAP_GROUP_MAPPING",
+];
+
+export default function LDAPSettingsPage() {
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl font-bold tracking-tight flex items-center gap-3" style={{ color: "rgb(var(--theme-text))" }}>
+                    <Key className="h-8 w-8 text-blue-500" />
+                    LDAP
+                </h1>
+                <p className="mt-1" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Enterprise LDAP and Active Directory authentication. Configure via gateway environment variables or config file.
+                </p>
+            </div>
+
+            <Card style={{ background: "rgb(var(--theme-surface))", borderColor: "rgb(var(--theme-border))" }}>
+                <CardHeader>
+                    <CardTitle style={{ color: "rgb(var(--theme-text))" }}>Configuration</CardTitle>
+                    <CardDescription style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        LDAP is configured on the gateway. Set the following environment variables or equivalent YAML in the gateway config.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <ul className="space-y-2 font-mono text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        {ENV_VARS.map((v) => (
+                            <li key={v} className="flex items-center gap-2">
+                                <FileCode className="h-4 w-4 shrink-0" />
+                                <code className="rounded px-1.5 py-0.5" style={{ background: "rgb(var(--theme-background))" }}>{v}</code>
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="mt-4 text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        After configuration, the login page will show an LDAP sign-in option when LDAP_ENABLED is true.
+                        Check gateway logs and SSO Integration for status.
+                    </p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/frontend/src/app/settings/saml/page.tsx
+++ b/frontend/src/app/settings/saml/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ShieldCheck, FileCode } from "lucide-react";
+
+const ENV_VARS = [
+    "SAML_ENABLED",
+    "SAML_IDP_METADATA_URL",
+    "SAML_ENTITY_ID",
+    "SAML_ROOT_URL",
+    "SAML_CERT_FILE",
+    "SAML_KEY_FILE",
+    "SAML_GROUPS_CLAIM",
+    "SAML_DEFAULT_ROLE",
+    "SAML_AUTO_PROVISION",
+    "SAML_GROUP_MAPPING",
+];
+
+export default function SAMLSettingsPage() {
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl font-bold tracking-tight flex items-center gap-3" style={{ color: "rgb(var(--theme-text))" }}>
+                    <ShieldCheck className="h-8 w-8 text-blue-500" />
+                    SAML 2.0
+                </h1>
+                <p className="mt-1" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Enterprise SAML 2.0 single sign-on. Configure via gateway environment variables or config file.
+                </p>
+            </div>
+
+            <Card style={{ background: "rgb(var(--theme-surface))", borderColor: "rgb(var(--theme-border))" }}>
+                <CardHeader>
+                    <CardTitle style={{ color: "rgb(var(--theme-text))" }}>Configuration</CardTitle>
+                    <CardDescription style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        SAML is configured on the gateway (Avika). Set the following environment variables or equivalent YAML in the gateway config.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <ul className="space-y-2 font-mono text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        {ENV_VARS.map((v) => (
+                            <li key={v} className="flex items-center gap-2">
+                                <FileCode className="h-4 w-4 shrink-0" />
+                                <code className="rounded px-1.5 py-0.5" style={{ background: "rgb(var(--theme-background))" }}>{v}</code>
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="mt-4 text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        The gateway exposes <code className="rounded px-1" style={{ background: "rgb(var(--theme-background))" }}>/saml/login</code>, <code className="rounded px-1" style={{ background: "rgb(var(--theme-background))" }}>/saml/metadata</code>, and ACS endpoints.
+                        When <code className="rounded px-1" style={{ background: "rgb(var(--theme-background))" }}>SAML_ENABLED=true</code>, users can sign in via your IdP. Check <strong>SSO Integration</strong> for status.
+                    </p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/frontend/src/app/settings/sso/page.tsx
+++ b/frontend/src/app/settings/sso/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { KeyRound, CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import Link from "next/link";
+
+interface SSOConfig {
+    oidc_enabled?: boolean;
+    ldap_enabled?: boolean;
+    saml_enabled?: boolean;
+}
+
+export default function SSOSettingsPage() {
+    const [config, setConfig] = useState<SSOConfig | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchConfig = async () => {
+            try {
+                const res = await apiFetch("/api/auth/sso-config");
+                const data = await res.json();
+                setConfig(data);
+            } catch {
+                setConfig({ oidc_enabled: false, ldap_enabled: false, saml_enabled: false });
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchConfig();
+    }, []);
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-64" style={{ color: "rgb(var(--theme-text))" }}>
+                <Loader2 className="h-8 w-8 animate-spin" />
+            </div>
+        );
+    }
+
+    const providers = [
+        { key: "oidc" as const, label: "OpenID Connect (OIDC)", href: "/settings", enabled: config?.oidc_enabled ?? false },
+        { key: "ldap" as const, label: "LDAP", href: "/settings/ldap", enabled: config?.ldap_enabled ?? false },
+        { key: "saml" as const, label: "SAML 2.0", href: "/settings/saml", enabled: config?.saml_enabled ?? false },
+    ];
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl font-bold tracking-tight flex items-center gap-3" style={{ color: "rgb(var(--theme-text))" }}>
+                    <KeyRound className="h-8 w-8 text-blue-500" />
+                    SSO Integration
+                </h1>
+                <p className="mt-1" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Single sign-on and enterprise authentication status. Configure each provider via environment variables or gateway config.
+                </p>
+            </div>
+
+            <Card style={{ background: "rgb(var(--theme-surface))", borderColor: "rgb(var(--theme-border))" }}>
+                <CardHeader>
+                    <CardTitle style={{ color: "rgb(var(--theme-text))" }}>Authentication providers</CardTitle>
+                    <CardDescription style={{ color: "rgb(var(--theme-text-muted))" }}>
+                        Status is read from the gateway. Enable OIDC, LDAP, or SAML in the gateway configuration.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    {providers.map((p) => (
+                        <div
+                            key={p.key}
+                            className="flex items-center justify-between py-3 px-4 rounded-lg border"
+                            style={{ borderColor: "rgb(var(--theme-border))", background: "rgb(var(--theme-background))" }}
+                        >
+                            <div className="flex items-center gap-3">
+                                {p.enabled ? (
+                                    <CheckCircle2 className="h-5 w-5 text-emerald-500" aria-hidden />
+                                ) : (
+                                    <XCircle className="h-5 w-5 text-slate-500" aria-hidden />
+                                )}
+                                <span className="font-medium" style={{ color: "rgb(var(--theme-text))" }}>
+                                    {p.label}
+                                </span>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <Badge
+                                    variant="outline"
+                                    className={p.enabled ? "bg-emerald-500/15 text-emerald-400 border-emerald-500/30" : "bg-slate-500/15 text-slate-400 border-slate-500/30"}
+                                >
+                                    {p.enabled ? "Enabled" : "Disabled"}
+                                </Badge>
+                                <Link
+                                    href={p.href}
+                                    className="text-sm font-medium hover:underline"
+                                    style={{ color: "rgb(var(--theme-primary))" }}
+                                >
+                                    {p.key === "oidc" ? "See General / Login" : "Configure"}
+                                </Link>
+                            </div>
+                        </div>
+                    ))}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/frontend/src/app/system/page.tsx
+++ b/frontend/src/app/system/page.tsx
@@ -256,6 +256,13 @@ function SystemHealthPageContent() {
                     </p>
                 </div>
                 <div className="flex items-center gap-3">
+                    <Link
+                        href="/system/preview"
+                        className="text-sm hover:underline"
+                        style={{ color: "rgb(var(--theme-text-muted))" }}
+                    >
+                        Preview new layout
+                    </Link>
                     <Badge 
                         variant="outline" 
                         className={stats.active === stats.total && stats.total > 0 

--- a/frontend/src/app/system/preview/page.tsx
+++ b/frontend/src/app/system/preview/page.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+/**
+ * System Dashboard — UX Redesign Preview
+ *
+ * This is a MOCKUP with static data to evaluate the proposed layout before implementation.
+ * Compare with /system (current) to decide whether to adopt this design.
+ *
+ * Design goals: scanability <3s, operational state first, minimal noise, progressive disclosure.
+ * See docs/UX-REDESIGN-SYSTEM-DASHBOARD.md for full plan and observations.
+ */
+
+import Link from "next/link";
+import { RefreshCw } from "lucide-react";
+
+// Mock data for preview
+const MOCK_INFRA = [
+  { name: "API Gateway", status: "healthy" as const },
+  { name: "PostgreSQL", status: "healthy" as const },
+  { name: "ClickHouse", status: "healthy" as const },
+  { name: "Agent Network", status: "healthy" as const, detail: "8 nodes" },
+];
+
+const MOCK_AGENTS = [
+  { id: "1", hostname: "nginx-alpha-dev", isPod: true, status: "online" as const, version: "1.7.0", lastSeen: "2s", needsUpdate: false },
+  { id: "2", hostname: "nginx-beta-uat", isPod: true, status: "online" as const, version: "1.7.0", lastSeen: "1s", needsUpdate: false },
+  { id: "3", hostname: "nginx-sidecar", isPod: true, status: "online" as const, version: "0.19.1", lastSeen: "3s", needsUpdate: true },
+  { id: "4", hostname: "nginx-edge", isPod: false, status: "online" as const, version: "1.6.8", lastSeen: "1s", needsUpdate: false },
+];
+
+const MOCK_EVENTS = [
+  { time: "12:41", msg: "nginx-beta-uat connected" },
+  { time: "12:38", msg: "nginx-sidecar update available" },
+  { time: "12:36", msg: "nginx-alpha-dev heartbeat" },
+];
+
+function StatusDot({ status }: { status: "healthy" | "degraded" | "critical" | "unknown" | "online" | "offline" }) {
+  const map: Record<string, { bg: string; label: string }> = {
+    healthy: { bg: "bg-emerald-400", label: "Healthy" },
+    online: { bg: "bg-emerald-400", label: "Online" },
+    degraded: { bg: "bg-amber-400", label: "Degraded" },
+    critical: { bg: "bg-red-400", label: "Critical" },
+    offline: { bg: "bg-red-400", label: "Offline" },
+    unknown: { bg: "bg-slate-400", label: "Unknown" },
+  };
+  const { bg, label } = map[status] || map.unknown;
+  return (
+    <span className="inline-flex items-center gap-1.5" role="status" aria-label={label}>
+      <span className={`h-2.5 w-2.5 rounded-full ${bg}`} aria-hidden />
+      <span className="text-sm font-medium capitalize">{label}</span>
+    </span>
+  );
+}
+
+function StatusRowAgent({ status, needsUpdate }: { status: string; needsUpdate?: boolean }) {
+  if (needsUpdate)
+    return (
+      <span className="inline-flex items-center gap-1.5" role="status">
+        <span className="h-2.5 w-2.5 rounded-full bg-amber-400" aria-hidden />
+        <span className="text-sm font-medium text-amber-400">Update</span>
+      </span>
+    );
+  const isOnline = status === "online";
+  return (
+    <span className="inline-flex items-center gap-1.5" role="status">
+      <span className={`h-2.5 w-2.5 rounded-full ${isOnline ? "bg-emerald-400" : "bg-red-400"}`} aria-hidden />
+      <span className={`text-sm font-medium ${isOnline ? "text-emerald-400" : "text-red-400"}`}>
+        {isOnline ? "Online" : "Offline"}
+      </span>
+    </span>
+  );
+}
+
+export default function SystemPreviewPage() {
+  return (
+    <div className="space-y-6 pb-8">
+      {/* Banner: this is a preview */}
+      <div
+        className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-sm"
+        style={{ color: "rgb(var(--theme-text))" }}
+      >
+        <strong>Preview:</strong> This is the proposed System dashboard layout (mock data).{" "}
+        <Link href="/system" className="underline hover:no-underline">
+          View current System page
+        </Link>
+        {" · "}
+        <span title="See docs/UX-REDESIGN-SYSTEM-DASHBOARD.md in the repo">Redesign plan (docs)</span>
+      </div>
+
+      {/* Page title */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold" style={{ color: "rgb(var(--theme-text))" }}>
+            System Overview
+          </h1>
+        </div>
+      </div>
+
+      {/* ─── SYSTEM HEALTH (inline metrics, no cards) ─── */}
+      <section>
+        <h2 className="text-xs font-semibold uppercase tracking-wider mb-3" style={{ color: "rgb(var(--theme-text-muted))" }}>
+          System Health
+        </h2>
+        <div
+          className="flex flex-wrap items-baseline gap-6 py-4 px-4 rounded-lg"
+          style={{ background: "rgb(var(--theme-surface))" }}
+        >
+          <div>
+            <span className="text-[28px] font-bold tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>
+              8 / 8
+            </span>
+            <span className="ml-2 text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+              Agents
+            </span>
+          </div>
+          <div>
+            <span className="text-[28px] font-bold tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>
+              100%
+            </span>
+            <span className="ml-2 text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+              Uptime
+            </span>
+          </div>
+          <div>
+            <span className="text-[28px] font-bold tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>
+              v1.7.0
+            </span>
+            <span className="ml-2 text-sm" style={{ color: "rgb(var(--theme-text-muted))" }}>
+              Version
+            </span>
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm hover:opacity-90"
+              style={{ borderColor: "rgb(var(--theme-border))", color: "rgb(var(--theme-text))" }}
+            >
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Two-column: Infrastructure | Agent Fleet */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+        {/* Left: Infrastructure */}
+        <section className="lg:col-span-4">
+          <h2 className="text-xs font-semibold uppercase tracking-wider mb-3" style={{ color: "rgb(var(--theme-text-muted))" }}>
+            Infrastructure
+          </h2>
+          <div
+            className="rounded-lg py-2"
+            style={{ background: "rgb(var(--theme-surface))" }}
+          >
+            {MOCK_INFRA.map((item) => (
+              <div
+                key={item.name}
+                className="flex items-center justify-between px-4 py-3 border-b last:border-b-0"
+                style={{ borderColor: "rgb(var(--theme-border))" }}
+              >
+                <span className="text-sm font-medium" style={{ color: "rgb(var(--theme-text))" }}>
+                  {item.name}
+                </span>
+                <div className="flex items-center gap-2">
+                  <StatusDot status={item.status} />
+                  {item.detail && (
+                    <span className="text-xs" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                      {item.detail}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Micro metrics (optional) */}
+          <h2 className="text-xs font-semibold uppercase tracking-wider mt-6 mb-3" style={{ color: "rgb(var(--theme-text-muted))" }}>
+            Traffic
+          </h2>
+          <div
+            className="rounded-lg px-4 py-3 grid grid-cols-3 gap-4 text-center"
+            style={{ background: "rgb(var(--theme-surface))" }}
+          >
+            <div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>284</div>
+              <div className="text-xs" style={{ color: "rgb(var(--theme-text-muted))" }}>req/s</div>
+            </div>
+            <div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>0.03%</div>
+              <div className="text-xs" style={{ color: "rgb(var(--theme-text-muted))" }}>errors</div>
+            </div>
+            <div>
+              <div className="text-lg font-semibold tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>18ms</div>
+              <div className="text-xs" style={{ color: "rgb(var(--theme-text-muted))" }}>p95</div>
+            </div>
+          </div>
+        </section>
+
+        {/* Right: Agent Fleet */}
+        <section className="lg:col-span-8">
+          <h2 className="text-xs font-semibold uppercase tracking-wider mb-3" style={{ color: "rgb(var(--theme-text-muted))" }}>
+            Agent Fleet
+          </h2>
+          <div
+            className="rounded-lg overflow-hidden"
+            style={{ background: "rgb(var(--theme-surface))" }}
+          >
+            <table className="w-full text-sm">
+              <thead>
+                <tr style={{ borderColor: "rgb(var(--theme-border))" }} className="border-b">
+                  <th className="text-left py-3 px-4 font-medium" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Agent
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Status
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Version
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                    Last Seen
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {MOCK_AGENTS.map((agent) => (
+                  <tr
+                    key={agent.id}
+                    className="border-b last:border-b-0 hover:bg-white/5"
+                    style={{ borderColor: "rgb(var(--theme-border))" }}
+                  >
+                    <td className="py-3 px-4">
+                      <Link
+                        href={`/servers/${agent.id}`}
+                        className="inline-flex items-center gap-2 font-medium hover:underline"
+                        style={{ color: "rgb(var(--theme-text))" }}
+                      >
+                        <span className="text-base" aria-label={agent.isPod ? "Kubernetes Pod" : "VM"}>
+                          {agent.isPod ? "⎈" : "🖥"}
+                        </span>
+                        {agent.hostname}
+                      </Link>
+                    </td>
+                    <td className="py-3 px-4">
+                      <StatusRowAgent status={agent.status} needsUpdate={agent.needsUpdate} />
+                    </td>
+                    <td className="py-3 px-4 tabular-nums" style={{ color: "rgb(var(--theme-text))" }}>
+                      {agent.version}
+                    </td>
+                    <td className="py-3 px-4 tabular-nums" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                      {agent.lastSeen}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Recent events (optional) */}
+          <h2 className="text-xs font-semibold uppercase tracking-wider mt-6 mb-3" style={{ color: "rgb(var(--theme-text-muted))" }}>
+            Recent Events
+          </h2>
+          <div
+            className="rounded-lg px-4 py-3 space-y-2"
+            style={{ background: "rgb(var(--theme-surface))" }}
+          >
+            {MOCK_EVENTS.map((ev, i) => (
+              <div key={i} className="flex items-center gap-3 text-sm">
+                <span className="tabular-nums font-mono text-xs w-10" style={{ color: "rgb(var(--theme-text-muted))" }}>
+                  {ev.time}
+                </span>
+                <span style={{ color: "rgb(var(--theme-text))" }}>{ev.msg}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard-layout.tsx
@@ -8,7 +8,7 @@ import {
     FileText, Heart, Cpu, ChevronDown, ChevronRight,
     Search, Bell, User, Menu, X, HelpCircle, LogOut,
     LayoutDashboard, Layers, GitBranch, Terminal, BookOpen, KeyRound, Globe,
-    LineChart, Users, FolderKanban, Lock, Info
+    LineChart, Users, FolderKanban, Lock, Info, Key, ShieldCheck
 } from "lucide-react";
 import { ProjectSelector } from "@/components/project-selector";
 import { EnvironmentTabs } from "@/components/environment-tabs";
@@ -90,6 +90,11 @@ const NAV_SECTIONS: NavSection[] = [
         items: [
             { href: "/settings", icon: <Settings />, label: "General" },
             { href: "/settings/integrations", icon: <Globe />, label: "Integrations" },
+            { href: "/settings/llm", icon: <Zap />, label: "LLM" },
+            { href: "/settings/waf", icon: <Lock />, label: "WAF" },
+            { href: "/settings/sso", icon: <KeyRound />, label: "SSO Integration" },
+            { href: "/settings/ldap", icon: <Key />, label: "LDAP" },
+            { href: "/settings/saml", icon: <ShieldCheck />, label: "SAML" },
         ],
     },
 ];


### PR DESCRIPTION
Settings:
- Add sidebar nav items: LLM, WAF, SSO Integration, LDAP, SAML under Settings
- Add /settings/sso page: shows OIDC/LDAP/SAML enabled status from gateway
- Add /settings/ldap page: env var reference for LDAP config
- Add /settings/saml page: env var reference for SAML 2.0 config
- sso-config API: return ldap_enabled/saml_enabled on error for SSO page

UX:
- Add docs/UX-REDESIGN-SYSTEM-DASHBOARD.md (plan + observations for SRE/dev)
- Add /system/preview: sample layout (metrics row, two-column, thin table)
- Add Preview new layout link on System page