### PR TITLE
fix: first login always fails, second succeeds

### DIFF
--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -3,6 +3,15 @@ import { getGatewayUrl } from "@/lib/gateway-url";
 
 const GATEWAY_URL = getGatewayUrl();
 
+/** Strip Domain= from cookie so the browser binds it to the response host (our app), not the gateway. */
+function stripCookieDomain(cookie: string): string {
+  return cookie
+    .split(";")
+    .map((part) => part.trim())
+    .filter((part) => !/^Domain=/i.test(part))
+    .join("; ");
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -21,10 +30,16 @@ export async function POST(request: NextRequest) {
     // Create response with same data
     const response = NextResponse.json(data, { status: gatewayResponse.status });
 
-    // Forward the session cookie from gateway
-    const setCookie = gatewayResponse.headers.get("set-cookie");
-    if (setCookie) {
-      response.headers.set("set-cookie", setCookie);
+    // Forward all Set-Cookie headers so the browser stores the session for this origin.
+    // Strip Domain so the cookie is bound to our host (fixes first-login-fails when gateway sets Domain).
+    const setCookies =
+      typeof gatewayResponse.headers.getSetCookie === "function"
+        ? gatewayResponse.headers.getSetCookie()
+        : gatewayResponse.headers.get("set-cookie")
+          ? [gatewayResponse.headers.get("set-cookie")!]
+          : [];
+    for (const cookie of setCookies) {
+      response.headers.append("set-cookie", stripCookieDomain(cookie));
     }
 
     return response;

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -50,13 +50,21 @@ export default function LoginPage() {
     setError("");
     setLoading(true);
 
+    const creds = { username, password };
+    if (!creds.username?.trim() || !creds.password) {
+      setError("Please enter username and password");
+      setLoading(false);
+      return;
+    }
+
     try {
       const response = await fetch(`${BASE_PATH}/api/auth/login`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify(creds),
       });
 
       const data = await response.json();


### PR DESCRIPTION
- Forward all Set-Cookie headers from gateway and strip Domain so cookie is bound to app host (fixes browser rejecting gateway-domain cookie)
- Add credentials: include to login fetch so the browser stores the session cookie
- Validate username/password non-empty before submitting to avoid an empty body