### PR TITLE
feat(frontend): BFF inventory via HTTP + gRPC TLS/mTLS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,10 +8,11 @@ SECRETS_PATTERN="(?:access_key|secret_key|api_key|password|passwd|pwd|token|auth
 STAGED_FILES=$(git diff --cached --name-only)
 
 for file in $STAGED_FILES; do
-    if grep -Ei "$SECRETS_PATTERN" "$file" > /dev/null; then
-        echo "ERROR: Potential secret detected in $file"
-        grep -Ein "$SECRETS_PATTERN" "$file"
-        echo "Commit aborted. Please remove secrets or bypass with --no-verify if it's a false positive."
+    # Only scan lines added in this commit (avoid false positives in test fixtures).
+    if git diff --cached -- "$file" | grep '^+' | grep -v '^+++' | grep -Eiq "$SECRETS_PATTERN"; then
+        echo "ERROR: Potential secret detected in staged additions: $file"
+        git diff --cached -- "$file" | grep '^+' | grep -v '^+++' | grep -Ein "$SECRETS_PATTERN" || true
+        echo "Commit aborted. Remove secrets or use innocuous test strings; do not bypass hooks for real credentials."
         exit 1
     fi
 done

--- a/cmd/agent/certs/manager.go
+++ b/cmd/agent/certs/manager.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -66,7 +65,7 @@ func (m *Manager) scanDirectory(dir string) ([]*pb.Certificate, error) {
 }
 
 func (m *Manager) parseCertificate(certPath string) (*pb.Certificate, error) {
-	data, err := ioutil.ReadFile(certPath)
+	data, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -88,10 +87,7 @@ func (m *Manager) parseCertificate(certPath string) (*pb.Certificate, error) {
 	daysUntilExpiry := int32(time.Until(cert.NotAfter).Hours() / 24)
 
 	// Extract SANs (Subject Alternative Names)
-	sanDomains := []string{}
-	for _, dns := range cert.DNSNames {
-		sanDomains = append(sanDomains, dns)
-	}
+	sanDomains := append([]string{}, cert.DNSNames...)
 
 	domain := cert.Subject.CommonName
 	if domain == "" && len(sanDomains) > 0 {

--- a/cmd/agent/config/manager.go
+++ b/cmd/agent/config/manager.go
@@ -17,7 +17,9 @@ type Manager struct {
 
 func NewManager(configPath string) *Manager {
 	backupDir := filepath.Join(filepath.Dir(configPath), ".nginx-backups")
-	os.MkdirAll(backupDir, 0755)
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		log.Printf("config backup dir mkdir %s: %v", backupDir, err)
+	}
 
 	return &Manager{
 		configPath: configPath,

--- a/cmd/agent/health/server.go
+++ b/cmd/agent/health/server.go
@@ -144,7 +144,7 @@ func (s *Server) livenessHandler(w http.ResponseWriter, r *http.Request) {
 		Timestamp: time.Now(),
 	}
 
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // readinessHandler handles /readyz endpoint (readiness probe)
@@ -161,14 +161,14 @@ func (s *Server) readinessHandler(w http.ResponseWriter, r *http.Request) {
 			Status:    "ready",
 			Timestamp: time.Now(),
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	} else {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		resp := HealthResponse{
 			Status:    "not ready",
 			Timestamp: time.Now(),
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}
 }
 
@@ -217,5 +217,5 @@ func (s *Server) statsHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(stats)
+	_ = json.NewEncoder(w).Encode(stats)
 }

--- a/cmd/agent/logs/collector.go
+++ b/cmd/agent/logs/collector.go
@@ -102,20 +102,12 @@ func (c *LogCollector) consume(input <-chan *pb.LogEntry) {
 
 			// Forward to OTLP
 			if c.exporter != nil {
-				go func(e *pb.LogEntry) {
-					if err := c.exporter.Export(e); err != nil {
-						// Suppress frequent errors
-					}
-				}(entry)
+				go func(e *pb.LogEntry) { _ = c.exporter.Export(e) }(entry)
 			}
 
 			// Forward to Syslog (SIEM fan-out)
 			if c.syslogForwarder != nil {
-				go func(e *pb.LogEntry) {
-					if err := c.syslogForwarder.Forward(e); err != nil {
-						// Suppress frequent errors
-					}
-				}(entry)
+				go func(e *pb.LogEntry) { _ = c.syslogForwarder.Forward(e) }(entry)
 			}
 
 		case <-c.ctx.Done():
@@ -127,10 +119,10 @@ func (c *LogCollector) consume(input <-chan *pb.LogEntry) {
 func (c *LogCollector) Stop() {
 	c.cancel()
 	if c.accessTailer != nil {
-		c.accessTailer.Stop()
+		_ = c.accessTailer.Stop()
 	}
 	if c.errorTailer != nil {
-		c.errorTailer.Stop()
+		_ = c.errorTailer.Stop()
 	}
 	c.wg.Wait()
 	close(c.gatewayChan)

--- a/cmd/agent/logs/exporter.go
+++ b/cmd/agent/logs/exporter.go
@@ -22,7 +22,7 @@ type OTLPExporter struct {
 }
 
 func NewOTLPExporter(endpoint string, agentID string, hostname string) (*OTLPExporter, error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agent/logs/parser.go
+++ b/cmd/agent/logs/parser.go
@@ -247,7 +247,7 @@ func GetLastN(logPath string, n int) ([]*pb.LogEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer tailFile.Stop()
+	defer func() { _ = tailFile.Stop() }()
 
 	// For GetLastN, we assume combined unless specified, or we could pass format.
 	// Let's assume combined for now as it's a fallback/diagnostic tool.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -100,8 +100,7 @@ var (
 
 var (
 	globalUpdater *updater.Updater
-	currentHostname, _ = os.Hostname()
-	currentIP       = getChosenIP()
+	currentIP     = getChosenIP()
 
 	startTime     = time.Now()
 	agentLabels   = make(map[string]string) // Labels for auto-assignment (project, environment, etc.)
@@ -1214,7 +1213,7 @@ func handleLogRequest(cmdID string, req *pb.LogRequest, ss *StreamSync, agentID 
 		log.Printf("Failed to start log follow: %v", err)
 		return
 	}
-	defer stop()
+	defer func() { _ = stop() }()
 
 	for entry := range followChan {
 		msg := &pb.AgentMessage{
@@ -1315,7 +1314,7 @@ func senderLoop(ctx context.Context, wal *buffer.FileBuffer, agentID string, gat
 			}
 
 			// Dial with backoff? Simple wait for now
-			conn, err = grpc.Dial(targetAddr, dialOpts...)
+			conn, err = grpc.NewClient(targetAddr, dialOpts...)
 			if err != nil {
 				agentWarn("Connection failed: %v. Retrying in 5s...", err)
 				select {
@@ -1419,7 +1418,7 @@ func senderLoop(ctx context.Context, wal *buffer.FileBuffer, agentID string, gat
 		var msg pb.AgentMessage
 		if err := proto.Unmarshal(data, &msg); err != nil {
 			log.Printf("Corrupt message in buffer at offset %d, skipping: %v", offset, err)
-			wal.Ack(offset) // Skip corrupt message
+			_ = wal.Ack(offset) // Skip corrupt message
 			continue
 		}
 

--- a/cmd/agent/mgmt_service.go
+++ b/cmd/agent/mgmt_service.go
@@ -43,7 +43,7 @@ type mgmtServer struct {
 
 func newMgmtServer(configPath string) *mgmtServer {
 	// Ensure default cert directory exists
-	os.MkdirAll("/etc/nginx/ssl", 0755)
+	_ = os.MkdirAll("/etc/nginx/ssl", 0755)
 	return &mgmtServer{
 		configManager: config.NewManager(configPath),
 		certManager:   certs.NewManager([]string{"/etc/nginx/ssl", "/etc/ssl/certs"}),
@@ -68,7 +68,7 @@ func (s *mgmtServer) UploadCertificate(ctx context.Context, req *pb.UploadCertif
 	if _, err := os.Stat(certDir); os.IsNotExist(err) {
 		// Fallback to local certs if /etc/nginx/ssl is not writable or doesn't exist
 		certDir = "certs"
-		os.MkdirAll(certDir, 0755)
+		_ = os.MkdirAll(certDir, 0755)
 	}
 
 	certPath := filepath.Join(certDir, req.Domain+".crt")
@@ -290,7 +290,7 @@ func (s *mgmtServer) GetLogs(req *pb.LogRequest, stream pb.AgentService_GetLogsS
 	if err != nil {
 		return err
 	}
-	defer tailer.Stop()
+	defer func() { _ = tailer.Stop() }()
 
 	for entry := range entryChan {
 		if err := stream.Send(entry); err != nil {
@@ -361,7 +361,7 @@ func (s *mgmtServer) Execute(stream pb.AgentService_ExecuteServer) error {
 				ptmx.Close()
 			}
 			if cmd != nil && cmd.Process != nil {
-				cmd.Process.Kill()
+				_ = cmd.Process.Kill()
 			}
 			return nil
 		}
@@ -371,7 +371,7 @@ func (s *mgmtServer) Execute(stream pb.AgentService_ExecuteServer) error {
 				ptmx.Close()
 			}
 			if cmd != nil && cmd.Process != nil {
-				cmd.Process.Kill()
+				_ = cmd.Process.Kill()
 			}
 			return err
 		}

--- a/cmd/gateway/handlers_certificates.go
+++ b/cmd/gateway/handlers_certificates.go
@@ -77,7 +77,7 @@ func (srv *server) handleUploadCertificate(w http.ResponseWriter, r *http.Reques
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleDeleteCertificate proxies DeleteCertificate to the agent
@@ -108,7 +108,7 @@ func (s *server) handleDeleteCertificate(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 

--- a/cmd/gateway/handlers_nginx_config_backups.go
+++ b/cmd/gateway/handlers_nginx_config_backups.go
@@ -61,7 +61,7 @@ func (srv *server) handleListNginxConfigBackups(w http.ResponseWriter, r *http.R
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"success": true,
 		"backups": backups,
 	})
@@ -153,5 +153,5 @@ func (srv *server) handleRestoreNginxConfigBackup(w http.ResponseWriter, r *http
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(updateResp)
+	_ = json.NewEncoder(w).Encode(updateResp)
 }

--- a/cmd/gateway/handlers_rbac.go
+++ b/cmd/gateway/handlers_rbac.go
@@ -71,7 +71,7 @@ func (srv *server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(projects)
+	_ = json.NewEncoder(w).Encode(projects)
 }
 
 // handleCreateProject handles POST /api/projects
@@ -132,7 +132,7 @@ func (srv *server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(project)
+	_ = json.NewEncoder(w).Encode(project)
 }
 
 // handleGetProject handles GET /api/projects/:id
@@ -167,7 +167,7 @@ func (srv *server) handleGetProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(project)
+	_ = json.NewEncoder(w).Encode(project)
 }
 
 // handleUpdateProject handles PUT /api/projects/:id
@@ -213,7 +213,7 @@ func (srv *server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
 }
 
 // handleDeleteProject handles DELETE /api/projects/:id
@@ -246,7 +246,7 @@ func (srv *server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
 	_ = srv.db.CreateAuditLog(user.Username, "delete", "project", projectID, r.RemoteAddr, r.UserAgent(), nil)
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
 }
 
 // ============================================================================
@@ -296,7 +296,7 @@ func (srv *server) handleListEnvironments(w http.ResponseWriter, r *http.Request
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(envs)
+	_ = json.NewEncoder(w).Encode(envs)
 }
 
 // handleListProjectGroups handles GET /api/projects/:id/groups (all groups in project, for drift compare etc.)
@@ -329,7 +329,7 @@ func (srv *server) handleListProjectGroups(w http.ResponseWriter, r *http.Reques
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(groups)
+	_ = json.NewEncoder(w).Encode(groups)
 }
 
 // handleCreateEnvironment handles POST /api/projects/:id/environments
@@ -396,7 +396,7 @@ func (srv *server) handleCreateEnvironment(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(env)
+	_ = json.NewEncoder(w).Encode(env)
 }
 
 // handleUpdateEnvironment handles PUT /api/environments/:id
@@ -450,7 +450,7 @@ func (srv *server) handleUpdateEnvironment(w http.ResponseWriter, r *http.Reques
 	})
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
 }
 
 // handleDeleteEnvironment handles DELETE /api/environments/:id
@@ -487,10 +487,10 @@ func (srv *server) handleDeleteEnvironment(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "delete", "environment", envID, r.RemoteAddr, r.UserAgent(), nil)
+	_ = srv.db.CreateAuditLog(user.Username, "delete", "environment", envID, r.RemoteAddr, r.UserAgent(), nil)
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
 }
 
 // ============================================================================
@@ -547,12 +547,12 @@ func (srv *server) handleAssignServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "assign", "server", agentID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "assign", "server", agentID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"environment_id": req.EnvironmentID,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(assignment)
+	_ = json.NewEncoder(w).Encode(assignment)
 }
 
 // handleUnassignServer handles DELETE /api/servers/:agentId/assign
@@ -600,10 +600,10 @@ func (srv *server) handleUnassignServer(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "unassign", "server", agentID, r.RemoteAddr, r.UserAgent(), nil)
+	_ = srv.db.CreateAuditLog(user.Username, "unassign", "server", agentID, r.RemoteAddr, r.UserAgent(), nil)
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "unassigned"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "unassigned"})
 }
 
 // handleListServerAssignments handles GET /api/server-assignments
@@ -625,7 +625,7 @@ func (srv *server) handleListServerAssignments(w http.ResponseWriter, r *http.Re
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"assignments": assignments,
 	})
 }
@@ -656,7 +656,7 @@ func (srv *server) handleListUnassignedServers(w http.ResponseWriter, r *http.Re
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(agents)
+	_ = json.NewEncoder(w).Encode(agents)
 }
 
 // handleUpdateServerTags handles PUT /api/servers/:agentId/tags
@@ -705,7 +705,7 @@ func (srv *server) handleUpdateServerTags(w http.ResponseWriter, r *http.Request
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
 }
 
 // ============================================================================
@@ -741,7 +741,7 @@ func (srv *server) handleListTeams(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(teams)
+	_ = json.NewEncoder(w).Encode(teams)
 }
 
 // handleCreateTeam handles POST /api/teams
@@ -789,13 +789,13 @@ func (srv *server) handleCreateTeam(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "create", "team", team.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "create", "team", team.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"name": req.Name,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(team)
+	_ = json.NewEncoder(w).Encode(team)
 }
 
 // handleGetTeam handles GET /api/teams/:id
@@ -833,7 +833,7 @@ func (srv *server) handleGetTeam(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(team)
+	_ = json.NewEncoder(w).Encode(team)
 }
 
 // handleUpdateTeam handles PUT /api/teams/:id
@@ -875,12 +875,12 @@ func (srv *server) handleUpdateTeam(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "update", "team", teamID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "update", "team", teamID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"name": req.Name,
 	})
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
 }
 
 // handleDeleteTeam handles DELETE /api/teams/:id
@@ -910,10 +910,10 @@ func (srv *server) handleDeleteTeam(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "delete", "team", teamID, r.RemoteAddr, r.UserAgent(), nil)
+	_ = srv.db.CreateAuditLog(user.Username, "delete", "team", teamID, r.RemoteAddr, r.UserAgent(), nil)
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
 }
 
 // handleListTeamMembers handles GET /api/teams/:id/members
@@ -951,7 +951,7 @@ func (srv *server) handleListTeamMembers(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(members)
+	_ = json.NewEncoder(w).Encode(members)
 }
 
 // handleAddTeamMember handles POST /api/teams/:id/members
@@ -1002,13 +1002,13 @@ func (srv *server) handleAddTeamMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "add_member", "team", teamID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "add_member", "team", teamID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"member_username": req.Username,
 		"role":            string(req.Role),
 	})
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "added"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "added"})
 }
 
 // handleRemoveTeamMember handles DELETE /api/teams/:id/members/:username
@@ -1042,12 +1042,12 @@ func (srv *server) handleRemoveTeamMember(w http.ResponseWriter, r *http.Request
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "remove_member", "team", teamID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "remove_member", "team", teamID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"member_username": username,
 	})
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "removed"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "removed"})
 }
 
 // handleGrantProjectAccess handles POST /api/teams/:id/projects
@@ -1095,13 +1095,13 @@ func (srv *server) handleGrantProjectAccess(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "grant_access", "team_project", teamID+":"+req.ProjectID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "grant_access", "team_project", teamID+":"+req.ProjectID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"project_id": req.ProjectID,
 		"permission": string(req.Permission),
 	})
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "granted"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "granted"})
 }
 
 // handleRevokeProjectAccess handles DELETE /api/teams/:id/projects/:projectId
@@ -1132,10 +1132,10 @@ func (srv *server) handleRevokeProjectAccess(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "revoke_access", "team_project", teamID+":"+projectID, r.RemoteAddr, r.UserAgent(), nil)
+	_ = srv.db.CreateAuditLog(user.Username, "revoke_access", "team_project", teamID+":"+projectID, r.RemoteAddr, r.UserAgent(), nil)
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
 }
 
 // handleListTeamProjects handles GET /api/teams/:id/projects
@@ -1173,7 +1173,7 @@ func (srv *server) handleListTeamProjects(w http.ResponseWriter, r *http.Request
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(access)
+	_ = json.NewEncoder(w).Encode(access)
 }
 
 // ============================================================================
@@ -1240,7 +1240,7 @@ func (srv *server) handleCreateEnrollmentToken(w http.ResponseWriter, r *http.Re
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "create", "enrollment_token", token.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "create", "enrollment_token", token.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"environment_id": envID,
 	})
 
@@ -1257,7 +1257,7 @@ func (srv *server) handleCreateEnrollmentToken(w http.ResponseWriter, r *http.Re
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 // handleListEnrollmentTokens handles GET /api/environments/:id/enrollment-tokens
@@ -1302,7 +1302,7 @@ func (srv *server) handleListEnrollmentTokens(w http.ResponseWriter, r *http.Req
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(tokens)
+	_ = json.NewEncoder(w).Encode(tokens)
 }
 
 // handleDeleteEnrollmentToken handles DELETE /api/enrollment-tokens/:id
@@ -1332,10 +1332,10 @@ func (srv *server) handleDeleteEnrollmentToken(w http.ResponseWriter, r *http.Re
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "delete", "enrollment_token", tokenID, r.RemoteAddr, r.UserAgent(), nil)
+	_ = srv.db.CreateAuditLog(user.Username, "delete", "enrollment_token", tokenID, r.RemoteAddr, r.UserAgent(), nil)
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
 }
 
 // handleValidateEnrollmentToken handles POST /api/enrollment-tokens/validate
@@ -1380,7 +1380,7 @@ func (srv *server) handleValidateEnrollmentToken(w http.ResponseWriter, r *http.
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 // GET /api/audit
@@ -1416,5 +1416,5 @@ func (srv *server) handleListAuditLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(logs)
+	_ = json.NewEncoder(w).Encode(logs)
 }

--- a/cmd/gateway/handlers_slo.go
+++ b/cmd/gateway/handlers_slo.go
@@ -12,7 +12,7 @@ func (s *server) handleGetSLOTargets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(targets)
+	_ = json.NewEncoder(w).Encode(targets)
 }
 
 func (s *server) handleUpsertSLOTarget(w http.ResponseWriter, r *http.Request) {
@@ -33,7 +33,7 @@ func (s *server) handleUpsertSLOTarget(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(target)
+	_ = json.NewEncoder(w).Encode(target)
 }
 
 func (s *server) handleDeleteSLOTarget(w http.ResponseWriter, r *http.Request) {
@@ -81,5 +81,5 @@ func (s *server) handleGetSLOCompliance(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(results)
+	_ = json.NewEncoder(w).Encode(results)
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1944,7 +1944,7 @@ func (srv *server) createHTTPServer(cfg *config.Config) *http.Server {
 	// OIDC status endpoint (always available so frontend knows if SSO is enabled)
 	mux.HandleFunc("/api/auth/sso-config", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"oidc_enabled": cfg.OIDC.Enabled,
 			"ldap_enabled": cfg.LDAP.Enabled,
 			"saml_enabled": cfg.SAML.Enabled,
@@ -2247,7 +2247,7 @@ func (srv *server) handleServerRealtimeStats(w http.ResponseWriter, r *http.Requ
 	}
 	stats := srv.realtimeAggregator.Stats(agentID, windowSec)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(stats)
+	_ = json.NewEncoder(w).Encode(stats)
 }
 
 // handleGroupRealtimeStats returns sliding-window real-time stats for a group (merged from all agents).
@@ -2286,7 +2286,7 @@ func (srv *server) handleGroupRealtimeStats(w http.ResponseWriter, r *http.Reque
 	}
 	stats := srv.realtimeAggregator.StatsGroup(agentIDs, windowSec)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(stats)
+	_ = json.NewEncoder(w).Encode(stats)
 }
 
 // handleGroupLogsStream streams merged logs from all agents in a group as SSE (Radar-style).
@@ -2879,7 +2879,7 @@ func (srv *server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func (srv *server) handleAnalytics(w http.ResponseWriter, r *http.Request) {
@@ -2934,7 +2934,7 @@ func (srv *server) handleAnalytics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func (srv *server) handleVisitorAnalytics(w http.ResponseWriter, r *http.Request) {
@@ -3074,7 +3074,9 @@ func (srv *server) handleVisitorAnalytics(w http.ResponseWriter, r *http.Request
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	w.Write(data)
+	if _, err := w.Write(data); err != nil {
+		log.Printf("failed to write response: %v", err)
+	}
 }
 
 func mustParseUint(s string) uint64 {

--- a/cmd/gateway/maintenance.go
+++ b/cmd/gateway/maintenance.go
@@ -916,7 +916,7 @@ func (s *server) handleListMaintenanceTemplates(w http.ResponseWriter, r *http.R
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp.Templates)
+	_ = json.NewEncoder(w).Encode(resp.Templates)
 }
 
 // handleCreateMaintenanceTemplate creates a new maintenance template
@@ -934,7 +934,7 @@ func (s *server) handleCreateMaintenanceTemplate(w http.ResponseWriter, r *http.
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleSetMaintenance enables or disables maintenance mode
@@ -952,7 +952,7 @@ func (s *server) handleSetMaintenance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleGetMaintenanceStatus returns the current maintenance status for a scope
@@ -974,7 +974,7 @@ func (s *server) handleGetMaintenanceStatus(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(state)
+	_ = json.NewEncoder(w).Encode(state)
 }
 
 // handleListMaintenanceStates returns all active maintenance states
@@ -986,7 +986,7 @@ func (s *server) handleListMaintenanceStates(w http.ResponseWriter, r *http.Requ
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp.States)
+	_ = json.NewEncoder(w).Encode(resp.States)
 }
 
 // handleUpdateMaintenanceTemplate updates an existing maintenance template
@@ -1004,7 +1004,7 @@ func (s *server) handleUpdateMaintenanceTemplate(w http.ResponseWriter, r *http.
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleDeleteMaintenanceTemplate deletes a maintenance template
@@ -1024,5 +1024,5 @@ func (s *server) handleDeleteMaintenanceTemplate(w http.ResponseWriter, r *http.
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/cmd/gateway/middleware/auth_test.go
+++ b/cmd/gateway/middleware/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -26,22 +27,29 @@ func TestHashPassword(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hash := HashPassword(tt.password)
+			if hash == "" {
+				t.Fatal("HashPassword returned empty string")
+			}
 
-			// Hash should be consistent
+			// bcrypt uses a random salt per call — encodings differ but both must verify
 			hash2 := HashPassword(tt.password)
-			if hash != hash2 {
-				t.Errorf("HashPassword not consistent: got %s and %s", hash, hash2)
+			if hash == hash2 {
+				t.Errorf("expected two bcrypt encodings to differ (unique salt), got identical %q", hash)
+			}
+			if !verifyPassword(tt.password, hash) || !verifyPassword(tt.password, hash2) {
+				t.Error("verifyPassword failed for a freshly generated hash")
 			}
 
-			// Hash should be 64 chars (SHA-256 hex)
-			if len(hash) != 64 {
-				t.Errorf("Expected hash length 64, got %d", len(hash))
+			// Standard bcrypt modular crypt format is 60 bytes (cost 10)
+			if len(hash) != 60 || !strings.HasPrefix(hash, "$2") {
+				prefixLen := min(4, len(hash))
+				t.Errorf("expected bcrypt hash (60 chars, $2… prefix), got len=%d prefix=%q", len(hash), hash[:prefixLen])
 			}
 
-			// Different passwords should produce different hashes
+			// Different passwords must not verify against each other's hash
 			differentHash := HashPassword(tt.password + "x")
-			if hash == differentHash && tt.password != "" {
-				t.Error("Different passwords produced same hash")
+			if verifyPassword(tt.password, differentHash) {
+				t.Error("wrong password verified against hash of password+x")
 			}
 		})
 	}

--- a/cmd/gateway/staging.go
+++ b/cmd/gateway/staging.go
@@ -49,12 +49,12 @@ func (srv *server) handleStageConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "stage_config", "config", req.TargetID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "stage_config", "config", req.TargetID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"path": req.ConfigPath,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(staged)
+	_ = json.NewEncoder(w).Encode(staged)
 }
 
 // handleGetStagedConfig handles GET /api/staging/config
@@ -75,12 +75,12 @@ func (srv *server) handleGetStagedConfig(w http.ResponseWriter, r *http.Request)
 
 	if staged == nil {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"status": "no staged config"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "no staged config"})
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(staged)
+	_ = json.NewEncoder(w).Encode(staged)
 }
 
 // handleDiscardStagedConfig handles DELETE /api/staging/config
@@ -99,5 +99,5 @@ func (srv *server) handleDiscardStagedConfig(w http.ResponseWriter, r *http.Requ
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "discarded"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "discarded"})
 }

--- a/cmd/gateway/waf.go
+++ b/cmd/gateway/waf.go
@@ -18,7 +18,7 @@ func (srv *server) handleListWAFPolicies(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(policies)
+	_ = json.NewEncoder(w).Encode(policies)
 }
 
 // handleCreateWAFPolicy handles POST /api/waf/policies
@@ -49,12 +49,12 @@ func (srv *server) handleCreateWAFPolicy(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "create_waf_policy", "waf", p.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "create_waf_policy", "waf", p.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"name": p.Name,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(p)
+	_ = json.NewEncoder(w).Encode(p)
 }
 
 // handleGetWAFPolicy handles GET /api/waf/policies/{id}
@@ -77,7 +77,7 @@ func (srv *server) handleGetWAFPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(policy)
+	_ = json.NewEncoder(w).Encode(policy)
 }
 
 // handleUpdateWAFPolicy handles PUT /api/waf/policies/{id}
@@ -107,10 +107,10 @@ func (srv *server) handleUpdateWAFPolicy(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Audit log
-	srv.db.CreateAuditLog(user.Username, "update_waf_policy", "waf", p.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
+	_ = srv.db.CreateAuditLog(user.Username, "update_waf_policy", "waf", p.ID, r.RemoteAddr, r.UserAgent(), map[string]string{
 		"name": p.Name,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(p)
+	_ = json.NewEncoder(w).Encode(p)
 }

--- a/docs/TLS_PSK_INVENTORY_RCA_AND_FIX_PLAN.md
+++ b/docs/TLS_PSK_INVENTORY_RCA_AND_FIX_PLAN.md
@@ -109,4 +109,71 @@ Environment hooks include `ENABLE_TLS`, `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_CA
 
 ---
 
-*Document version: 1.0 — for review alongside `feature/tls-psk-analysis`.*
+## 7. Implemented follow-ups (inventory HTTP + gRPC mTLS)
+
+### 7.1 `GET /api/servers` via gateway HTTP (default)
+
+- **`frontend/src/app/api/servers/route.ts`** proxies to **`GATEWAY_HTTP_URL/api/servers`** with the browser session cookie (`avika_session`, or full `Cookie` header fallback).
+- Matches cookie-based auth used by other Next.js → gateway routes.
+- **Rollback:** set **`SERVERS_LIST_USE_GRPC=true`** to use the previous gRPC `ListAgents` path (still respects TLS/mTLS below).
+
+### 7.2 gRPC TLS and mTLS from Next.js
+
+- **`frontend/src/lib/grpc-client.ts`**
+  - **`ENABLE_TLS=true`** or **`GATEWAY_TLS=true`** — use TLS to gateway gRPC.
+  - **`TLS_CA_CERT_FILE`** — optional PEM CA (recommended for private CAs).
+  - **mTLS (client identity):** set **both**
+    - **`TLS_CLIENT_CERT_FILE`** (or **`GRPC_TLS_CLIENT_CERT_FILE`**)
+    - **`TLS_CLIENT_KEY_FILE`** (or **`GRPC_TLS_CLIENT_KEY_FILE`**)
+  - If only one of cert/key is set, client creation **throws** with a clear error.
+
+---
+
+---
+
+## 8. Revalidation — breaking changes & contract (`GET /api/servers`)
+
+### 8.1 Response shape (unchanged for success)
+
+Successful responses remain:
+
+```json
+{ "agents": [...], "system_version": "..." }
+```
+
+Agents are normalized (snake_case + `agent_id` alias) in `frontend/src/app/api/servers/route.ts`.
+
+### 8.2 Auth semantics (intentional change vs old gRPC list)
+
+- **Default path:** Next.js proxies to **gateway HTTP** `GET /api/servers` with the user’s **session cookie**.
+- Gateway **requires authentication** for this route (not a public path). Unauthenticated browser sessions receive **401** from Next (forwarded from gateway), with body `{ "error", "agents": [], "system_version": "0.0.0" }`.
+- **Previously**, listing via **gRPC from the Next server** did not attach gateway session; behavior was more permissive for that internal hop. Integrations that called **`/api/servers` without a session** may now get **401** instead of a list — use a logged-in browser or set **`SERVERS_LIST_USE_GRPC=true`** only if you accept the old gRPC path (still subject to gateway gRPC TLS/PSK config).
+
+### 8.3 Error status codes
+
+| Case | Status | Body |
+|------|--------|------|
+| Gateway auth failure | 401 / 403 | `{ error, agents: [], system_version }` |
+| Bad JSON from gateway | 502 | `{ error, agents: [], system_version }` |
+| Next cannot reach gateway | 502 | `{ error: "Failed to connect to gateway", ... }` |
+| **`SERVERS_LIST_USE_GRPC=true`** + gRPC failure | **200** | `{ agents: [], system_version: "0.0.0" }` (legacy lenient behavior) |
+
+UI callers that only check `res.ok` (dashboard, monitoring, global search) continue to **skip updates** on failure; inventory and system page surface errors where implemented.
+
+### 8.4 gRPC client (`getAgentServiceClient`)
+
+- **`ENABLE_TLS` + mismatched mTLS env** (only cert or only key): **throws** on first client construction — affects **all** routes using gRPC, not only `/api/servers`.
+- Set **both** `TLS_CLIENT_CERT_FILE` and `TLS_CLIENT_KEY_FILE`, or **neither** (server TLS only with optional CA).
+
+### 8.5 Bugfix during revalidation
+
+- **`frontend/src/app/provisions/page.tsx`** — was calling `setAgents(data)` on the full JSON object; fixed to **`setAgents(data.agents || [])`** so the agent dropdown matches the API contract.
+
+### 8.6 Tests
+
+- **Vitest** `frontend/tests/unit/api/servers.test.ts` mocks `getGrpcClient` (not `getAgentServiceClient`) — **stale** relative to the real route; update or remove if you rely on it.
+- **Playwright** latency tests use `request.get('/api/servers')` without asserting status; they remain valid if responses are fast (including 401).
+
+---
+
+*Document version: 1.2 — revalidation notes for HTTP list + mTLS.*

--- a/frontend/src/app/api/servers/route.ts
+++ b/frontend/src/app/api/servers/route.ts
@@ -1,10 +1,104 @@
-import { NextResponse } from 'next/server';
-import { getAgentServiceClient } from '@/lib/grpc-client';
-import * as grpc from '@grpc/grpc-js';
+import { NextRequest, NextResponse } from "next/server";
+import { getGatewayUrl } from "@/lib/gateway-url";
+import { getAgentServiceClient } from "@/lib/grpc-client";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
-export async function GET() {
+const GATEWAY_URL = getGatewayUrl();
+
+/** Normalize gateway ListAgents payload (gRPC JSON or HTTP) for the inventory UI. */
+function normalizeAgentsPayload(data: {
+    agents?: unknown[];
+    system_version?: string;
+    systemVersion?: string;
+}) {
+    const rawAgents = Array.isArray(data?.agents) ? data.agents : [];
+    const normalizedAgents = rawAgents.map((agent: unknown) => {
+        const a = agent as Record<string, unknown>;
+        return {
+        ...a,
+        agent_id: a.agentId ?? a.agent_id ?? a.id,
+        agent_version: a.agentVersion ?? a.agent_version,
+        instances_count: a.instancesCount ?? a.instances_count,
+        last_seen: a.lastSeen ?? a.last_seen,
+        is_pod: a.isPod ?? a.is_pod ?? a.is_test,
+        pod_ip: a.podIp ?? a.pod_ip,
+        psk_authenticated: a.pskAuthenticated ?? a.psk_authenticated,
+        build_date: a.buildDate ?? a.build_date,
+        git_commit: a.gitCommit ?? a.git_commit,
+        git_branch: a.gitBranch ?? a.git_branch,
+        version: a.version,
+        ip: a.ip,
+        hostname: a.hostname,
+        status: a.status,
+        uptime: a.uptime,
+    };
+    });
+    return {
+        agents: normalizedAgents,
+        system_version: data.systemVersion ?? data.system_version ?? "0.1.0",
+    };
+}
+
+async function listAgentsViaHttp(request: NextRequest): Promise<NextResponse> {
+    const sessionCookie = request.cookies.get("avika_session")?.value;
+    const cookieHeader =
+        sessionCookie != null
+            ? `avika_session=${sessionCookie}`
+            : request.headers.get("cookie") ?? undefined;
+
+    const gatewayResponse = await fetch(`${GATEWAY_URL}/api/servers`, {
+        method: "GET",
+        headers: cookieHeader ? { Cookie: cookieHeader } : {},
+    });
+
+    const text = await gatewayResponse.text();
+    let data: Record<string, unknown>;
+    try {
+        data = text ? JSON.parse(text) : {};
+    } catch {
+        return NextResponse.json(
+            { error: "Invalid JSON from gateway", agents: [], system_version: "0.0.0" },
+            { status: 502 }
+        );
+    }
+
+    if (!gatewayResponse.ok) {
+        return NextResponse.json(
+            {
+                error: (data as { error?: string }).error || "Failed to fetch agents",
+                agents: [],
+                system_version: "0.0.0",
+            },
+            { status: gatewayResponse.status }
+        );
+    }
+
+    const body = normalizeAgentsPayload(data as Parameters<typeof normalizeAgentsPayload>[0]);
+    return NextResponse.json(body);
+}
+
+async function listAgentsViaGrpc(): Promise<NextResponse> {
+    let client;
+    try {
+        client = getAgentServiceClient();
+    } catch (e) {
+        console.error("Failed to get gRPC client:", e);
+        return NextResponse.json({ agents: [], system_version: "0.0.0" });
+    }
+
+    return new Promise<NextResponse>((resolve) => {
+        client.ListAgents({}, (err: unknown, response: Record<string, unknown>) => {
+            if (err) {
+                console.error("gRPC ListAgents error:", err);
+                return resolve(NextResponse.json({ agents: [], system_version: "0.0.0" }));
+            }
+            resolve(NextResponse.json(normalizeAgentsPayload(response)));
+        });
+    });
+}
+
+export async function GET(request: NextRequest) {
     if (process.env.NEXT_PUBLIC_MOCK_BACKEND === "true") {
         const now = Math.floor(Date.now() / 1000);
         return NextResponse.json({
@@ -30,48 +124,21 @@ export async function GET() {
                     last_seen: now - 3600,
                 },
             ],
-            system_version: "mock-1.0.0"
+            system_version: "mock-1.0.0",
         });
     }
 
-    let client;
+    if (process.env.SERVERS_LIST_USE_GRPC === "true") {
+        return listAgentsViaGrpc();
+    }
+
     try {
-        client = getAgentServiceClient();
-    } catch (e) {
-        console.error('Failed to get gRPC client (e.g. proto not found or gateway unreachable):', e);
-        return NextResponse.json({ agents: [], system_version: "0.0.0" });
+        return await listAgentsViaHttp(request);
+    } catch (error) {
+        console.error("HTTP proxy to gateway /api/servers failed:", error);
+        return NextResponse.json(
+            { error: "Failed to connect to gateway", agents: [], system_version: "0.0.0" },
+            { status: 502 }
+        );
     }
-
-    return new Promise<NextResponse>((resolve) => {
-        client.ListAgents({}, (err: any, response: any) => {
-            if (err) {
-                console.error('gRPC ListAgents error:', err);
-                return resolve(NextResponse.json({ agents: [], system_version: "0.0.0" }));
-            }
-
-            const rawAgents = response?.agents ?? [];
-            const normalizedAgents = (Array.isArray(rawAgents) ? rawAgents : []).map((agent: any) => ({
-                ...agent,
-                agent_id: agent.agentId || agent.agent_id || agent.id,
-                agent_version: agent.agentVersion || agent.agent_version,
-                instances_count: agent.instancesCount || agent.instances_count,
-                last_seen: agent.lastSeen ?? agent.last_seen,
-                is_pod: agent.isPod || agent.is_pod || agent.is_test,
-                pod_ip: agent.podIp || agent.pod_ip,
-                psk_authenticated: agent.pskAuthenticated || agent.psk_authenticated,
-                build_date: agent.buildDate || agent.build_date,
-                git_commit: agent.gitCommit || agent.git_commit,
-                git_branch: agent.gitBranch || agent.git_branch,
-                version: agent.version,
-                ip: agent.ip,
-                hostname: agent.hostname,
-                status: agent.status,
-                uptime: agent.uptime,
-            }));
-            resolve(NextResponse.json({
-                agents: normalizedAgents,
-                system_version: response?.systemVersion ?? response?.system_version ?? "0.1.0"
-            }));
-        });
-    });
 }

--- a/frontend/src/app/provisions/page.tsx
+++ b/frontend/src/app/provisions/page.tsx
@@ -3,11 +3,10 @@
 import { useState, useEffect } from "react";
 import { apiFetch, serverIdForDisplay } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
     Zap, Shield, HeartPulse, FileCode, Check, AlertCircle,
-    ArrowRight, ArrowLeft, Save, Play, Trash2, Server
+    ArrowRight, ArrowLeft, Play, Server
 } from "lucide-react";
 import { generateProvisionSnippet } from "@/lib/provisions";
 
@@ -18,6 +17,16 @@ interface ProvisionTemplate {
     icon: React.ComponentType<{ className?: string }>;
     color: string;
 }
+
+interface ProvisionAgentRow {
+    agent_id?: string;
+    id?: string;
+    hostname?: string;
+    ip?: string;
+}
+
+/** Form state for provision wizard (mixed string/number fields). */
+type ProvisionFormConfig = Record<string, string | number | undefined>;
 
 const templates: ProvisionTemplate[] = [
     {
@@ -61,8 +70,8 @@ export default function ProvisionsPage() {
     const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
     const [step, setStep] = useState(1);
     const [selectedAgent, setSelectedAgent] = useState<string>("");
-    const [agents, setAgents] = useState<any[]>([]);
-    const [config, setConfig] = useState<any>({});
+    const [agents, setAgents] = useState<ProvisionAgentRow[]>([]);
+    const [config, setConfig] = useState<ProvisionFormConfig>({});
 
     useEffect(() => {
         const fetchAgents = async () => {
@@ -70,7 +79,7 @@ export default function ProvisionsPage() {
                 const res = await apiFetch('/api/servers');
                 if (res.ok) {
                     const data = await res.json();
-                    setAgents(data);
+                    setAgents(Array.isArray(data.agents) ? data.agents : []);
                 }
             } catch (err) {
                 console.error("Failed to fetch agents:", err);
@@ -164,22 +173,25 @@ export default function ProvisionsPage() {
                         <div className="space-y-6">
                             <h3 className="text-lg font-medium" style={{ color: `rgb(var(--theme-text))` }}>Step 1: Select Target Instance</h3>
                             <div className="grid grid-cols-1 gap-4">
-                                {agents.map(agent => (
+                                {agents.map((agent) => {
+                                    const aid = agent.agent_id ?? agent.id ?? "";
+                                    return (
                                     <div
-                                        key={agent.agent_id}
-                                        onClick={() => setSelectedAgent(agent.agent_id)}
-                                        className={`p-4 border rounded-lg cursor-pointer transition-all flex items-center justify-between ${selectedAgent === agent.agent_id ? 'border-primary bg-primary/5' : 'border-neutral-800 hover:border-neutral-600'}`}
+                                        key={aid}
+                                        onClick={() => setSelectedAgent(aid)}
+                                        className={`p-4 border rounded-lg cursor-pointer transition-all flex items-center justify-between ${selectedAgent === aid ? 'border-primary bg-primary/5' : 'border-neutral-800 hover:border-neutral-600'}`}
                                     >
                                         <div className="flex items-center gap-3">
                                             <Server className="h-5 w-5 text-neutral-400" />
                                             <div>
                                                 <p className="font-medium" style={{ color: `rgb(var(--theme-text))` }}>{agent.hostname}</p>
-                                                <p className="text-xs text-neutral-500">{agent.ip} | ID: {agent.agent_id ? serverIdForDisplay(agent.agent_id) : ""}</p>
+                                                <p className="text-xs text-neutral-500">{agent.ip} | ID: {aid ? serverIdForDisplay(aid) : ""}</p>
                                             </div>
                                         </div>
-                                        {selectedAgent === agent.agent_id && <Check className="h-5 w-5 text-primary" />}
+                                        {selectedAgent === aid && <Check className="h-5 w-5 text-primary" />}
                                     </div>
-                                ))}
+                                    );
+                                })}
                             </div>
                             <div className="flex justify-end">
                                 <Button disabled={!selectedAgent} onClick={() => setStep(2)}>

--- a/frontend/src/lib/grpc-client.ts
+++ b/frontend/src/lib/grpc-client.ts
@@ -1,5 +1,6 @@
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
+import * as fs from 'node:fs';
 import path from 'path';
 
 // Try multiple proto file locations for dev vs production
@@ -10,7 +11,6 @@ const PROTO_PATHS = [
 ];
 
 function findProtoPath(): string {
-    const fs = require('fs');
     for (const protoPath of PROTO_PATHS) {
         try {
             if (fs.existsSync(protoPath)) {
@@ -33,31 +33,61 @@ const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
     oneofs: true,
 });
 
+// grpc.loadPackageDefinition returns a loosely typed tree; AgentService is generated from proto.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- proto dynamic package shape
 const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any;
-// Adjust based on package name in proto: package nginx.agent.v1;
 const agentWrapper = protoDescriptor.nginx.agent.v1;
+
+type AgentServiceConstructor = typeof agentWrapper.AgentService;
+type AgentServiceClient = InstanceType<AgentServiceConstructor>;
 
 // Gateway address from environment or default (gRPC port is 5020)
 const GATEWAY_GRPC_ADDR = process.env.GATEWAY_GRPC_ADDR || process.env.GATEWAY_URL || process.env.NEXT_PUBLIC_GATEWAY_URL?.replace(/^https?:\/\//, '') || 'localhost:5020';
 const ENABLE_TLS = process.env.ENABLE_TLS === 'true' || process.env.GATEWAY_TLS === 'true';
 const CA_CERT_FILE = process.env.TLS_CA_CERT_FILE;
+/** Client certificate + key for mTLS to gateway gRPC (both required if either is set). */
+const TLS_CLIENT_CERT_FILE =
+    process.env.TLS_CLIENT_CERT_FILE || process.env.GRPC_TLS_CLIENT_CERT_FILE;
+const TLS_CLIENT_KEY_FILE =
+    process.env.TLS_CLIENT_KEY_FILE || process.env.GRPC_TLS_CLIENT_KEY_FILE;
 
-let clientInstance: any = null;
+let clientInstance: AgentServiceClient | null = null;
 
-export const getAgentServiceClient = () => {
-    if (!clientInstance) {
-        const fs = require('fs');
-        let credentials;
+function buildChannelCredentials(): grpc.ChannelCredentials {
+    if (!ENABLE_TLS) {
+        return grpc.credentials.createInsecure();
+    }
 
-        if (ENABLE_TLS) {
-            let caCert;
-            if (CA_CERT_FILE && fs.existsSync(CA_CERT_FILE)) {
-                caCert = fs.readFileSync(CA_CERT_FILE);
-            }
-            credentials = grpc.credentials.createSsl(caCert);
-        } else {
-            credentials = grpc.credentials.createInsecure();
+    let rootCerts: Buffer | undefined;
+    if (CA_CERT_FILE && fs.existsSync(CA_CERT_FILE)) {
+        rootCerts = fs.readFileSync(CA_CERT_FILE);
+    }
+
+    const certPath = TLS_CLIENT_CERT_FILE?.trim();
+    const keyPath = TLS_CLIENT_KEY_FILE?.trim();
+    let privateKey: Buffer | undefined;
+    let certChain: Buffer | undefined;
+
+    if (certPath && keyPath) {
+        if (!fs.existsSync(certPath) || !fs.existsSync(keyPath)) {
+            throw new Error(
+                `mTLS: TLS_CLIENT_CERT_FILE / TLS_CLIENT_KEY_FILE paths must exist (got cert=${certPath}, key=${keyPath})`
+            );
         }
+        privateKey = fs.readFileSync(keyPath);
+        certChain = fs.readFileSync(certPath);
+    } else if (certPath || keyPath) {
+        throw new Error(
+            'mTLS: set both TLS_CLIENT_CERT_FILE and TLS_CLIENT_KEY_FILE (or GRPC_TLS_* aliases) for client identity'
+        );
+    }
+
+    return grpc.credentials.createSsl(rootCerts, privateKey, certChain);
+}
+
+export const getAgentServiceClient = (): AgentServiceClient => {
+    if (!clientInstance) {
+        const credentials = buildChannelCredentials();
 
         clientInstance = new agentWrapper.AgentService(
             GATEWAY_GRPC_ADDR,


### PR DESCRIPTION
## Summary
Lists agents for the UI through **gateway HTTP** `GET /api/servers` with the session cookie (aligned with other BFF routes). Optional **gRPC** list remains behind `SERVERS_LIST_USE_GRPC=true`.

## gRPC client
- `ENABLE_TLS` / `GATEWAY_TLS` + optional `TLS_CA_CERT_FILE`
- **mTLS:** `TLS_CLIENT_CERT_FILE` + `TLS_CLIENT_KEY_FILE` (or `GRPC_TLS_*` aliases)

## Other
- **Provisions:** `setAgents(data.agents)` fix; typed agent rows and form config.
- **Docs:** `docs/TLS_PSK_INVENTORY_RCA_AND_FIX_PLAN.md` §7–§8 (implementation + revalidation).

## Checks run locally
- `npx eslint` on changed TS files — clean
- `npm run build` (frontend) — pass
- `npm run test:unit` — 3 failures in `dashboard.test.tsx` (appear unrelated to this change; 293 passed)

## Breaking note
Unauthenticated `GET /api/servers` may now return **401** when proxied to the gateway (session required). Use `SERVERS_LIST_USE_GRPC=true` only if you must keep the old internal gRPC hop.