### PR TITLE
fix: audit fixes — remove mock data, fix report route, wiring gaps (v1.118)

### DIFF
--- a/cmd/gateway/handlers_rbac.go
+++ b/cmd/gateway/handlers_rbac.go
@@ -50,24 +50,8 @@ func (srv *server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(projects) == 0 {
-		// Mock data for demonstration
-		projects = []Project{
-			{
-				ID:          "proj-1",
-				Name:        "E-commerce Platform",
-				Slug:        "ecommerce",
-				Description: "Main customer-facing portal and API",
-				CreatedAt:   time.Now().Add(-720 * time.Hour),
-			},
-			{
-				ID:          "proj-2",
-				Name:        "Internal Admin Tools",
-				Slug:        "admin",
-				Description: "Internal management dashboard and tools",
-				CreatedAt:   time.Now().Add(-360 * time.Hour),
-			},
-		}
+	if projects == nil {
+		projects = []Project{}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -280,19 +264,8 @@ func (srv *server) handleListEnvironments(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if len(envs) == 0 {
-		// Mock data for demonstration
-		if projectID == "proj-1" {
-			envs = []Environment{
-				{ID: "env-1", ProjectID: projectID, Name: "Production", Slug: "production", Color: "#ef4444", IsProduction: true, SortOrder: 1},
-				{ID: "env-2", ProjectID: projectID, Name: "Staging", Slug: "staging", Color: "#eab308", IsProduction: false, SortOrder: 2},
-				{ID: "env-3", ProjectID: projectID, Name: "Development", Slug: "development", Color: "#3b82f6", IsProduction: false, SortOrder: 3},
-			}
-		} else if projectID == "proj-2" {
-			envs = []Environment{
-				{ID: "env-4", ProjectID: projectID, Name: "Office", Slug: "office", Color: "#10b981", IsProduction: true, SortOrder: 1},
-			}
-		}
+	if envs == nil {
+		envs = []Environment{}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2074,8 +2074,12 @@ func (srv *server) createHTTPServer(cfg *config.Config) *http.Server {
 		srv.handleTerminal(w, r, upgrader)
 	})))
 
-	// Export report endpoint with rate limiting and auth
-	mux.Handle("/export-report", authManager.AuthMiddleware(publicPaths)(middleware.RateLimitMiddleware(rateLimiter, cfg.Security.EnableRateLimit)(http.HandlerFunc(srv.handleExportReport))))
+	// Export report endpoint with rate limiting and auth.
+	// Registered at both legacy path (/export-report) and the canonical API path
+	// (/api/reports/download) that the frontend uses.
+	exportReportHandler := authManager.AuthMiddleware(publicPaths)(middleware.RateLimitMiddleware(rateLimiter, cfg.Security.EnableRateLimit)(http.HandlerFunc(srv.handleExportReport)))
+	mux.Handle("/export-report", exportReportHandler)
+	mux.Handle("GET /api/reports/download", exportReportHandler)
 
 	// Geo API endpoint
 	mux.Handle("/api/geo", authManager.AuthMiddleware(publicPaths)(http.HandlerFunc(srv.handleGeoData)))

--- a/deploy/helm/avika/values.yaml
+++ b/deploy/helm/avika/values.yaml
@@ -235,7 +235,7 @@ components:
     image:
       useGlobalRegistry: true
       repository: avika-gateway
-      tag: "1.117.0"
+      tag: "1.118.0"
       pullPolicy: Always
     terminationGracePeriodSeconds: 35
     
@@ -323,7 +323,7 @@ components:
     image:
       useGlobalRegistry: true
       repository: avika-frontend
-      tag: "1.117.0"
+      tag: "1.118.0"
       pullPolicy: Always
     
     ports:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { apiFetch } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
@@ -26,12 +27,13 @@ import { OnboardingWizard } from "@/components/OnboardingWizard";
 import { DashboardBuilderButton, useDashboardWidgets } from "@/components/DashboardBuilder";
 
 
-// Convert time range value to API window parameter
+// Convert time range value to API window parameter.
+// Absolute date ranges are not yet supported by the analytics API — it accepts
+// only relative windows (1h, 7d, etc.). We fall back to 1h and warn the user.
 function getWindowParam(timeRange: TimeRange): string {
     if (timeRange.type === 'relative' && timeRange.value) {
         return timeRange.value;
     }
-    // Default to 1h for absolute ranges (API would need to support from/to params)
     return '1h';
 }
 
@@ -76,10 +78,11 @@ export default function Home() {
         label: 'Last 1 hour'
     });
 
+    const [statsLoaded, setStatsLoaded] = useState(false);
     const [stats, setStats] = useState({
-        requestRate: "0",
-        errorRate: "0",
-        avgLatency: "0",
+        requestRate: "—",
+        errorRate: "—",
+        avgLatency: "—",
         trafficHistory: [] as any[],
         statusCounts: { success: 0, redirect: 0, clientError: 0, serverError: 0 },
         topUrls: [] as any[],
@@ -207,6 +210,7 @@ export default function Home() {
                     topUrls,
                     totalRequests: totalReqs,
                 });
+                setStatsLoaded(true);
 
                 // Store current stats as baseline for next refresh cycle's trend comparison.
                 // On subsequent fetches, prevStats holds the real data from the previous poll,
@@ -318,7 +322,15 @@ export default function Home() {
                     <DashboardBuilderButton widgets={widgets} onTogglePin={togglePin} />
                     <TimeRangePicker
                         value={timeRange}
-                        onChange={setTimeRange}
+                        onChange={(tr) => {
+                            if (tr.type === 'absolute') {
+                                toast.warning("Absolute date ranges not yet supported", {
+                                    description: "The analytics API accepts relative windows only (1h, 24h, 7d). Showing last 1 hour instead.",
+                                    duration: 5000,
+                                });
+                            }
+                            setTimeRange(tr);
+                        }}
                     />
                     <Badge
                         variant="outline"

--- a/frontend/src/app/system/page.tsx
+++ b/frontend/src/app/system/page.tsx
@@ -493,7 +493,7 @@ function SystemHealthPageContent() {
 }
 
 function isOnline(lastSeen: any) {
-    if (!lastSeen) return true;
+    if (!lastSeen) return false; // no heartbeat = not online
     const now = Math.floor(Date.now() / 1000);
     return (now - parseInt(lastSeen)) < 180;
 }

--- a/frontend/src/app/waf/page.tsx
+++ b/frontend/src/app/waf/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { formatTsDate } from "@/lib/format-timestamp";
 import {
     Table, TableBody, TableCell, TableHead, TableHeader, TableRow
@@ -99,7 +100,14 @@ export default function WAFPage() {
                                         <div className="flex flex-col items-center gap-2" style={{ color: "rgb(var(--theme-text-muted))" }}>
                                             <Shield className="h-12 w-12 opacity-20" />
                                             <p>No WAF policies defined yet.</p>
-                                            <Button variant="outline" size="sm" className="mt-2">Deploy OWASP Core Rule Set</Button>
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                className="mt-2"
+                                                onClick={() => toast.info("OWASP Core Rule Set deployment coming soon", {
+                                                    description: "Create a WAF policy above, then deploy it to your agents."
+                                                })}
+                                            >Deploy OWASP Core Rule Set</Button>
                                         </div>
                                     </TableCell>
                                 </TableRow>
@@ -139,7 +147,14 @@ export default function WAFPage() {
                                                 <Button variant="ghost" size="sm" className="hover:bg-purple-500/10 text-purple-400">
                                                     <Settings className="h-4 w-4" />
                                                 </Button>
-                                                <Button variant="ghost" size="sm" className="hover:bg-blue-500/10 text-blue-400">
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="hover:bg-blue-500/10 text-blue-400"
+                                                    onClick={() => toast.info("WAF deployment coming soon", {
+                                                        description: "Policy distribution to agents is on the roadmap. Policies are stored and ready to deploy."
+                                                    })}
+                                                >
                                                     Deploy
                                                 </Button>
                                             </div>


### PR DESCRIPTION
## Summary

- **Remove mock project/environment fallback** — backend was silently returning fake 'E-commerce Platform' demo data when DB had no projects; now returns empty array
- **Fix reports PDF/Excel download** — frontend called `/api/reports/download` but backend only served `/export-report`; both paths now registered
- **Dashboard KPI shows `—` not `0` before load** — prevents misleading zeros before first successful API response
- **null last_seen = offline** — `isOnline(null)` was returning `true`; agents without heartbeat now correctly show as offline
- **WAF deploy buttons wired** — no-op buttons now show informative toast about roadmap status
- **Absolute date range warns user** — silent fallback to 1h now shows a toast explaining the API limitation

## Test plan
- [ ] Fresh install with empty DB: project selector shows empty state (no phantom E-commerce Platform)
- [ ] Reports page → Download PDF → file actually downloads
- [ ] System Health page: agent with no last_seen shows Offline not Online
- [ ] Dashboard on first load: KPI cards show `—` not `0` during loading
- [ ] WAF page → Deploy → informative toast appears
- [ ] Dashboard time picker → select absolute range → warning toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)