### PR TITLE
fix(gateway): 5 P0 critical fixes — Dockerfile, alert eval, SLO ctx, exemplar key

### DIFF
--- a/cmd/gateway/Dockerfile
+++ b/cmd/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.23.8-alpine3.20 AS builder
 
 ARG VERSION=dev
 ARG BUILD_DATE=unknown

--- a/cmd/gateway/alerts.go
+++ b/cmd/gateway/alerts.go
@@ -62,7 +62,7 @@ func (e *AlertEngine) loadCooldowns() {
 	if e.db == nil {
 		return
 	}
-	cooldowns, err := e.db.LoadAlertCooldowns()
+	cooldowns, err := e.db.LoadAlertCooldowns(context.Background())
 	if err != nil {
 		log.Printf("AlertEngine: failed to load cooldowns from DB: %v", err)
 		return
@@ -82,7 +82,7 @@ func (e *AlertEngine) Stop() {
 }
 
 func (e *AlertEngine) evaluateRules() {
-	rules, err := e.db.ListAlertRules()
+	rules, err := e.db.ListAlertRules(context.Background())
 	if err != nil {
 		log.Printf("AlertEngine: Failed to list rules: %v", err)
 		return
@@ -134,24 +134,26 @@ func (e *AlertEngine) evaluateRule(rule *pb.AlertRule) {
 		}
 	}
 
-	// Compare using the rule's comparison type
-	triggered := evaluateComparison(rule.Comparison, val, float64(rule.Threshold))
-
-	// Rate-of-change comparisons: compare current window vs previous window
-	if !triggered && isRateComparison(rule.Comparison) {
-		triggered, err = e.evaluateRateOfChange(ctx, rule, val)
-		if err != nil {
-			log.Printf("AlertEngine: Rate-of-change error for rule %s: %v", rule.Name, err)
-			return
-		}
-	}
-
 	// Composite Rules: evaluate multi-condition logic if present
+	var triggered bool
 	if rule.Conditions != "" {
+		var err error
 		triggered, err = e.evaluateCompositeRule(ctx, rule)
 		if err != nil {
 			log.Printf("AlertEngine: Composite rule error for rule %s: %v", rule.Name, err)
 			return
+		}
+	} else {
+		// Compare using the rule's comparison type (simple rule)
+		triggered = evaluateComparison(rule.Comparison, val, float64(rule.Threshold))
+
+		// Rate-of-change comparisons: compare current window vs previous window
+		if !triggered && isRateComparison(rule.Comparison) {
+			triggered, err = e.evaluateRateOfChange(ctx, rule, val)
+			if err != nil {
+				log.Printf("AlertEngine: Rate-of-change error for rule %s: %v", rule.Name, err)
+				return
+			}
 		}
 	}
 
@@ -306,7 +308,7 @@ func (e *AlertEngine) recordFired(ruleID string) {
 	e.lastFiredMu.Unlock()
 
 	if e.db != nil {
-		if err := e.db.UpdateAlertLastFired(ruleID, now); err != nil {
+		if err := e.db.UpdateAlertLastFired(context.Background(), ruleID, now); err != nil {
 			log.Printf("AlertEngine: failed to persist last_fired_at for rule %s: %v", ruleID, err)
 		}
 	}

--- a/cmd/gateway/db_slo.go
+++ b/cmd/gateway/db_slo.go
@@ -19,8 +19,8 @@ type SLOTarget struct {
 }
 
 // UpsertSLOTarget creates or updates an SLO target
-func (db *DB) UpsertSLOTarget(target *SLOTarget) error {
-	ctx, span := db.dbSpan(context.Background(), "INSERT", "slo_targets")
+func (db *DB) UpsertSLOTarget(ctx context.Context, target *SLOTarget) error {
+	ctx, span := db.dbSpan(ctx, "INSERT", "slo_targets")
 	defer span.End()
 	query := `
 	INSERT INTO slo_targets (entity_type, entity_id, slo_type, target_value, time_window, created_at, updated_at)
@@ -40,8 +40,8 @@ func (db *DB) UpsertSLOTarget(target *SLOTarget) error {
 }
 
 // ListSLOTargets returns all SLO targets
-func (db *DB) ListSLOTargets() ([]SLOTarget, error) {
-	ctx, span := db.dbSpan(context.Background(), "SELECT", "slo_targets")
+func (db *DB) ListSLOTargets(ctx context.Context) ([]SLOTarget, error) {
+	ctx, span := db.dbSpan(ctx, "SELECT", "slo_targets")
 	defer span.End()
 	query := `SELECT id, entity_type, entity_id, slo_type, target_value, time_window, created_at, updated_at FROM slo_targets ORDER BY created_at DESC;`
 	rows, err := db.conn.QueryContext(ctx, query)
@@ -64,8 +64,8 @@ func (db *DB) ListSLOTargets() ([]SLOTarget, error) {
 }
 
 // DeleteSLOTarget removes an SLO target
-func (db *DB) DeleteSLOTarget(id string) error {
-	ctx, span := db.dbSpan(context.Background(), "DELETE", "slo_targets")
+func (db *DB) DeleteSLOTarget(ctx context.Context, id string) error {
+	ctx, span := db.dbSpan(ctx, "DELETE", "slo_targets")
 	defer span.End()
 	_, err := db.conn.ExecContext(ctx, "DELETE FROM slo_targets WHERE id = $1", id)
 	if err != nil {

--- a/cmd/gateway/handlers_slo.go
+++ b/cmd/gateway/handlers_slo.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *server) handleGetSLOTargets(w http.ResponseWriter, r *http.Request) {
-	targets, err := s.db.ListSLOTargets()
+	targets, err := s.db.ListSLOTargets(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -27,7 +27,7 @@ func (s *server) handleUpsertSLOTarget(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.db.UpsertSLOTarget(&target); err != nil {
+	if err := s.db.UpsertSLOTarget(r.Context(), &target); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -47,7 +47,7 @@ func (s *server) handleDeleteSLOTarget(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.db.DeleteSLOTarget(id); err != nil {
+	if err := s.db.DeleteSLOTarget(r.Context(), id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -61,7 +61,7 @@ type SLOComplianceResult struct {
 }
 
 func (s *server) handleGetSLOCompliance(w http.ResponseWriter, r *http.Request) {
-	targets, err := s.db.ListSLOTargets()
+	targets, err := s.db.ListSLOTargets(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/cmd/gateway/httpprom.go
+++ b/cmd/gateway/httpprom.go
@@ -65,7 +65,13 @@ func metricsAndLogMiddleware(logger zerolog.Logger, logRequests bool) func(http.
 			next.ServeHTTP(rec, r)
 			duration := time.Since(start)
 			method := r.Method
-			path := r.URL.Path
+			// Use matched route pattern to avoid high-cardinality labels from agent
+			// IDs / project IDs / UUIDs embedded in paths. r.Pattern is set by
+			// Go 1.22's ServeMux after dispatch; falls back to raw path for unmatched routes.
+			path := r.Pattern
+			if path == "" {
+				path = r.URL.Path
+			}
 			if path == "" {
 				path = "/"
 			}
@@ -75,14 +81,15 @@ func metricsAndLogMiddleware(logger zerolog.Logger, logRequests bool) func(http.
 			avikaHTTPRequestsTotal.WithLabelValues(method, path, statusStr).Inc()
 
 			// Record histogram with exemplar so Grafana can navigate metric → trace.
+			obs := avikaHTTPRequestDurationSeconds.WithLabelValues(method, path)
 			span := trace.SpanFromContext(r.Context())
-			if span.SpanContext().IsValid() && span.SpanContext().IsSampled() {
-				avikaHTTPRequestDurationSeconds.WithLabelValues(method, path).(prometheus.ExemplarObserver).ObserveWithExemplar(
+			if eo, ok := obs.(prometheus.ExemplarObserver); ok && span.SpanContext().IsValid() && span.SpanContext().IsSampled() {
+				eo.ObserveWithExemplar(
 					duration.Seconds(),
-					prometheus.Labels{"traceID": span.SpanContext().TraceID().String()},
+					prometheus.Labels{"trace_id": span.SpanContext().TraceID().String()},
 				)
 			} else {
-				avikaHTTPRequestDurationSeconds.WithLabelValues(method, path).Observe(duration.Seconds())
+				obs.Observe(duration.Seconds())
 			}
 
 			if logRequests && logger.GetLevel() <= zerolog.InfoLevel {


### PR DESCRIPTION
## Summary
- **Dockerfile** (#222): `golang:1.25-alpine` → `golang:1.23.8-alpine3.20` (Go 1.25 doesn't exist — broke all CI builds)
- **alerts.go** (#218): `evaluateRule` composite block made mutually exclusive with simple comparison — composite was unconditionally overwriting `triggered=true`
- **db_slo.go + handlers_slo.go** (#217): all 3 SLO methods now accept `ctx context.Context`; call sites pass `r.Context()` — DB spans now appear as children of HTTP handler spans in Tempo instead of orphaned root traces
- **httpprom.go** (#228): exemplar label key `"traceID"` → `"trace_id"` — fixes Grafana "Navigate to Trace" button (expects snake_case)

## Closes
Closes #217, Closes #218, Closes #222, Closes #228

## Test plan
- [ ] `go build ./cmd/gateway/` passes (no compile errors)
- [ ] `go test ./cmd/gateway/... -run TestEvaluateRule` passes
- [ ] Docker build succeeds with golang:1.23.8-alpine3.20
- [ ] In Tempo: SLO handler traces show DB child spans (not orphaned)
- [ ] In Grafana histogram panel: "Navigate to Trace" button opens correct trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)