### PR TITLE
fix(frontend): 2 P0 fixes — WCAG AA contrast + IST timezone mandate

### DIFF
--- a/frontend/src/components/settings/display-settings.tsx
+++ b/frontend/src/components/settings/display-settings.tsx
@@ -27,6 +27,7 @@ const REFRESH_INTERVALS = [
 ];
 
 const TIMEZONES = [
+    { label: "IST (Asia/Kolkata)", value: "Asia/Kolkata" },
     { label: "Browser", value: "browser" },
     { label: "UTC", value: "UTC" },
 ];

--- a/frontend/src/lib/format-timestamp.ts
+++ b/frontend/src/lib/format-timestamp.ts
@@ -13,16 +13,16 @@
  */
 
 function getUserTimezone(): string | undefined {
-  if (typeof window === "undefined") return "UTC"; // SSR — default to UTC
+  if (typeof window === "undefined") return "Asia/Kolkata"; // SSR — default to IST
   try {
     const raw = localStorage.getItem("avika-user-settings");
     if (raw) {
       const settings = JSON.parse(raw);
       const tz = settings?.display?.timezone;
-      if (tz === "UTC") return "UTC";
+      if (tz === "UTC" || tz === "Asia/Kolkata" || tz === "browser") return tz;
     }
   } catch {}
-  return undefined; // browser default
+  return "Asia/Kolkata"; // default to IST
 }
 
 function toDate(input: string | number | Date): Date {
@@ -38,7 +38,7 @@ function toDate(input: string | number | Date): Date {
 export function formatTs(input: string | number | Date): string {
   const d = toDate(input);
   const tz = getUserTimezone();
-  return d.toLocaleString("en-US", {
+  const formatted = d.toLocaleString("en-IN", {
     timeZone: tz,
     month: "short",
     day: "2-digit",
@@ -48,13 +48,14 @@ export function formatTs(input: string | number | Date): string {
     second: "2-digit",
     hour12: false,
   });
+  return tz === "Asia/Kolkata" ? `${formatted} IST` : formatted;
 }
 
 /** Date only: "Apr 05, 2026" */
 export function formatTsDate(input: string | number | Date): string {
   const d = toDate(input);
   const tz = getUserTimezone();
-  return d.toLocaleDateString("en-US", {
+  return d.toLocaleDateString("en-IN", {
     timeZone: tz,
     month: "short",
     day: "2-digit",
@@ -66,7 +67,7 @@ export function formatTsDate(input: string | number | Date): string {
 export function formatTsTime(input: string | number | Date): string {
   const d = toDate(input);
   const tz = getUserTimezone();
-  return d.toLocaleTimeString("en-US", {
+  return d.toLocaleTimeString("en-IN", {
     timeZone: tz,
     hour: "2-digit",
     minute: "2-digit",
@@ -79,7 +80,7 @@ export function formatTsTime(input: string | number | Date): string {
 export function formatTsShort(input: string | number | Date): string {
   const d = toDate(input);
   const tz = getUserTimezone();
-  return d.toLocaleString("en-US", {
+  const formatted = d.toLocaleString("en-IN", {
     timeZone: tz,
     month: "short",
     day: "2-digit",
@@ -87,13 +88,14 @@ export function formatTsShort(input: string | number | Date): string {
     minute: "2-digit",
     hour12: false,
   });
+  return tz === "Asia/Kolkata" ? `${formatted} IST` : formatted;
 }
 
 /** Precise time with milliseconds: "00:30:05.123" */
 export function formatTsPrecise(input: string | number | Date): string {
   const d = toDate(input);
   const tz = getUserTimezone();
-  const base = d.toLocaleTimeString("en-US", {
+  const base = d.toLocaleTimeString("en-IN", {
     timeZone: tz,
     hour: "2-digit",
     minute: "2-digit",

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -26,7 +26,7 @@ export const themes = {
         surfaceLight: "243 244 246",   // #F3F4F6  (hover)
         text: "17 24 39",              // #111827
         textMuted: "75 85 99",         // #4B5563
-        textDim: "156 163 175",        // #9CA3AF
+        textDim: "107 114 128",        // #6B7280
         primary: "37 99 235",          // #2563EB
         success: "22 163 74",          // #16A34A
         warning: "217 119 6",          // #D97706

--- a/frontend/src/lib/user-settings.tsx
+++ b/frontend/src/lib/user-settings.tsx
@@ -42,7 +42,7 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   display: {
     defaultTimeRange: "now-1h",
     refreshInterval: "30s",
-    timezone: "browser",
+    timezone: "Asia/Kolkata",
   },
   telemetry: {
     collectionInterval: "10",


### PR DESCRIPTION
## Summary
- **themes.ts** (#226): Light theme `textDim` changed from `#9CA3AF` (2.54:1 contrast) to `#6B7280` (4.65:1 contrast) — now passes WCAG AA minimum of 4.5:1 on white background
- **user-settings.tsx** (#225): Default timezone changed from `"browser"` to `"Asia/Kolkata"`
- **display-settings.tsx** (#225): Added `"IST (Asia/Kolkata)"` as first option in timezone selector
- **format-timestamp.ts** (#225): Changed locale from `"en-US"` to `"en-IN"`; appends `" IST"` suffix when timezone is Asia/Kolkata

## Closes
Closes #225, Closes #226

## Test plan
- [ ] Light theme secondary text visibly readable (passes WCAG contrast check)
- [ ] Default timezone for new users is IST (Asia/Kolkata)
- [ ] All timestamps on dashboard, analytics, alerts pages display with " IST" suffix
- [ ] Timestamp format: "05 Jun 2026, 16:30:45 IST"

🤖 Generated with [Claude Code](https://claude.com/claude-code)